### PR TITLE
Add note to readme about experimental status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## Note: This is an experimental project that is actively being developed and tested - features may change without notice
+
 # Dockyard - MCP Server Container Builder
 
 > **A centralized repository for packaging Model Context Protocol (MCP) servers into containers**


### PR DESCRIPTION
We have the same notice in https://github.com/stacklok/toolhive-studio to indicate that the project is still experimental