### PR TITLE
feat: add mcp-server-circleci MCP server package

### DIFF
--- a/npx/mcp-server-circleci/spec.yaml
+++ b/npx/mcp-server-circleci/spec.yaml
@@ -1,0 +1,29 @@
+# MCP Server CircleCI Configuration
+# MCP server for CircleCI CI/CD platform operations
+# Package: https://www.npmjs.com/package/@circleci/mcp-server-circleci
+# Repository: https://github.com/CircleCI-Public/mcp-server-circleci
+# Will build as: ghcr.io/stacklok/dockyard/npx/mcp-server-circleci:0.14.0
+
+metadata:
+  name: mcp-server-circleci
+  description: "MCP server for CircleCI, enabling natural language interactions with CircleCI functionality"
+  version: "0.14.0"
+  protocol: npx
+
+spec:
+  package: "@circleci/mcp-server-circleci"
+  version: "0.14.0"
+
+provenance:
+  repository_uri: "https://github.com/CircleCI-Public/mcp-server-circleci"
+  repository_ref: "refs/heads/main"
+
+# Optional: Security allowlist
+security:
+  allowed_issues:
+    - code: W001
+      reason: "CI/CD operations require specific terminology for pipeline control (run, rollback, rerun) that may trigger prompt injection warnings"
+    - code: TF001
+      reason: "CircleCI must access private build data, configurations, and secrets while interacting with external systems for CI/CD operations"
+    - code: TF002
+      reason: "CI/CD platforms inherently perform destructive operations like canceling builds, running pipelines, and modifying configurations"


### PR DESCRIPTION
## Description

Add packaging for mcp-server-circleci v0.14.0, the official CircleCI MCP server for CI/CD operations.

## Details

- **Package**: https://www.npmjs.com/package/@circleci/mcp-server-circleci
- **Repository**: https://github.com/CircleCI-Public/mcp-server-circleci
- **Version**: 0.14.0
- **Protocol**: npx (Node.js/npm)

## Security Analysis

### Thorough security scan analysis completed:

- **W001 (Prompt Injection Warnings)**: 4 occurrences on tools that use CI/CD terminology
  - Tools affected: `recommend_prompt_template_tests`, `rerun_workflow`, `find_underused_resource_classes`, `analyze_diff`
  - These are false positives from legitimate CI/CD operation names

- **TF001 (Data Leak Toxic Flow)**: Expected for CI/CD platforms
  - 13 tools can produce untrusted content (from external sources)
  - 10 tools can access private data (build logs, configs, secrets)
  - 3 tools can act as public sinks
  - This is inherent to CI/CD platforms bridging private repos with public build systems

- **TF002 (Destructive Toxic Flow)**: Expected for CI/CD operations
  - 13 tools can produce untrusted content
  - 5 tools can perform destructive actions (run pipelines, cancel builds, modify configs)
  - These are legitimate CI/CD operations

## Testing

- ✅ Build validation passed
- ✅ Security scan passed with properly justified allowlisted issues
- ✅ 16 tools scanned and analyzed

## Related PRs

This completes the batch of MCP server packages being added to Dockyard.