### PR TITLE
Add chrome-devtools-mcp MCP server

### DIFF
--- a/npx/chrome-devtools-mcp/spec.yaml
+++ b/npx/chrome-devtools-mcp/spec.yaml
@@ -1,0 +1,18 @@
+# Chrome DevTools MCP server
+# Package URL: https://www.npmjs.com/package/chrome-devtools-mcp
+# Repository: https://github.com/ChromeDevTools/chrome-devtools-mcp
+# Will build as: ghcr.io/stacklok/dockyard/npx/chrome-devtools-mcp:0.6.0
+
+metadata:
+  name: chrome-devtools-mcp
+  description: "MCP server for Chrome DevTools. Provides browser automation, debugging, and performance analysis via Chrome DevTools."
+  version: "0.6.0"
+  protocol: npx
+
+spec:
+  package: "chrome-devtools-mcp"
+  version: "0.6.0"
+
+provenance:
+  repository_uri: "https://github.com/ChromeDevTools/chrome-devtools-mcp"
+  repository_ref: "refs/tags/chrome-devtools-mcp-v0.6.0"


### PR DESCRIPTION
This PR adds the `chrome-devtools-mcp` MCP server to the Dockyard project.

**What it does:**  
Provides browser automation, advanced debugging, and performance analysis via Chrome DevTools for AI coding agents.

**Package registry:**  
[NPM: chrome-devtools-mcp](https://www.npmjs.com/package/chrome-devtools-mcp)

**Source repository:**  
[GitHub: ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp)

The server is added under `npx/chrome-devtools-mcp/spec.yaml` following project conventions.