### PR TITLE
Use Go version from go.mod instead of hardcoding

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go.mod'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  GO_VERSION: '1.24'
-
 jobs:
 
   lint:
@@ -22,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
@@ -40,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Cache Go modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
## Summary
- Removes hardcoded Go versions from GitHub Actions workflows
- Updates all `setup-go` actions to use `go-version-file: 'go.mod'`
- Ensures workflows automatically use the Go version specified in go.mod

## Changes
- **ci.yml**: Removed `GO_VERSION: '1.24'` env var and updated both lint and build jobs
- **build-containers.yml**: Changed from hardcoded `go-version: '1.25'` to `go-version-file: 'go.mod'`

## Benefits
- Single source of truth for Go version (go.mod)
- No manual workflow updates needed when Go version changes
- Fixes inconsistency where build-containers.yml used 1.25 while go.mod specifies 1.24.4
- Renovate updates to go.mod will automatically apply to all workflows

## Test plan
- [x] Verify ci.yml workflow picks up correct Go version
- [x] Verify build-containers.yml workflow picks up correct Go version
- [x] Confirm workflows run successfully with go.mod version

🤖 Generated with [Claude Code](https://claude.com/claude-code)