### PR TITLE
feat: add netbird build

### DIFF
--- a/go/netbird/spec.yaml
+++ b/go/netbird/spec.yaml
@@ -1,0 +1,18 @@
+# Netbird MCP Server Configuration
+# MCP server for interacting with Netbird networking
+# Go module: go install github.com/aantti/mcp-netbird/cmd/mcp-netbird@latest
+# Repository: https://github.com/aantti/mcp-netbird
+# Will build as: ghcr.io/stacklok/dockyard/go/netbird
+
+metadata:
+  name: netbird
+  description: "MCP Server for Netbird"
+  protocol: go
+
+spec:
+  package: "github.com/aantti/mcp-netbird/cmd/mcp-netbird"
+  version: "latest"
+
+provenance:
+  repository_uri: "https://github.com/aantti/mcp-netbird?tab=readme-ov-file"
+  repository_ref: "refs/heads/main"


### PR DESCRIPTION
The Netbird MCP container image referenced in the ToolHive registry is no longer available in Docker Hub.

Adding to Dockyard so we don't have to remove it entirely.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>