### PR TITLE
fix(security): add E001 to playwright-mcp allowlist

### DIFF
--- a/npx/playwright-mcp/spec.yaml
+++ b/npx/playwright-mcp/spec.yaml
@@ -19,6 +19,8 @@ provenance:
 
 security:
   allowed_issues:
+    - code: "E001"
+      reason: "Tool documentation contains legitimate browser automation instructions (e.g., key names like 'ArrowLeft') that may resemble prompt injection patterns but are necessary for proper browser control functionality"
     - code: "TF001"
       reason: "Data leak risk acceptable - tool designed for browser automation and web testing workflows where external content interaction is essential. Users should be aware of potential data exposure when automating web interactions."
     - code: "TF002"


### PR DESCRIPTION
## Summary
- Adds E001 to the security allowlist for playwright-mcp
- Fixes security scan failure in PR #172

## Context
The mcp-scan security scanner flagged E001 (malicious input detection) on tool #11 (browser_press_key) in the @playwright/mcp package. This is a false positive - the tool documentation contains legitimate browser automation instructions (e.g., key names like 'ArrowLeft') that the scanner misinterpreted as potential prompt injection.

This is Microsoft's official Playwright MCP package, and the flagged content is necessary documentation for proper browser control functionality.

## Test plan
- [ ] Security scan should pass for playwright-mcp
- [ ] PR #172 (updating to v0.0.46) can be re-merged after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)