### PR TITLE
Remove `platforms` from container build invocation

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -383,7 +383,6 @@ jobs:
         with:
           context: ${{ steps.dockerfile.outputs.dockerfile_dir }}
           file: ${{ steps.dockerfile.outputs.dockerfile_path }}
-          platforms: linux/amd64
           load: true
           tags: local-scan:${{ steps.meta.outputs.server_name }}-${{ steps.meta.outputs.version }}
           cache-from: type=gha


### PR DESCRIPTION
This ensures it runs on the machine's platform and thus is faster

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
