### PR TITLE
fix(ci): add timeouts to build job

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -261,6 +261,7 @@ jobs:
   build-containers:
     needs: [discover-configs, verify-provenance, mcp-security-scan]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     # Only proceed if security scans passed (provenance check is informational only)
     if: ${{ needs.discover-configs.outputs.changed-configs != '[]' && needs.mcp-security-scan.result == 'success' }}
     strategy:
@@ -356,6 +357,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
+        timeout-minutes: 30
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: ${{ steps.dockerfile.outputs.dockerfile_dir }}


### PR DESCRIPTION
At least once or twice per full-rebuild run of the build workflow we're encountering a QEMU core dump detailed in #192.

This adds step- and job-level timeouts to fail faster than the default GitHub timeout of 6 hours.

Typical job runtimes are <10 minutes, so the 60 minute timeout should provide plenty of buffer.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>