### PR TITLE
feat: add support for build args in spec.yaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ metadata:
 spec:
   package: "your-package-name"    # Required: Package name from registry
   version: "1.0.0"               # Required: Specific version to build
+  args:                          # Optional: Additional arguments for the package
+    - "arg1"                     # Arguments are passed to the entrypoint
+    - "arg2"
 
 provenance:                       # Optional but recommended
   repository_uri: "https://github.com/user/repo"  # Expected source repository (used for verification)
@@ -97,10 +100,24 @@ metadata:
 spec:
   package: "@your-org/mcp-server"  # NPM package name
   version: "2.1.0"
+  args:                            # Optional: Add required CLI arguments
+    - "start"                      # For packages that need specific commands
 
 provenance:
   repository_uri: "https://github.com/your-org/mcp-server"
   repository_ref: "refs/tags/v2.1.0"
+```
+
+**Real-world example** (LaunchDarkly MCP server):
+```yaml
+# Some packages require specific CLI arguments to run
+# These are baked into the container entrypoint
+spec:
+  package: "@launchdarkly/mcp-server"
+  version: "0.4.2"
+  args:
+    - "start"  # Required by LaunchDarkly's CLI
+# Results in: ENTRYPOINT ["npx", "@launchdarkly/mcp-server", "start"]
 ```
 
 #### UVX (Python) Example

--- a/cmd/dockhand/main.go
+++ b/cmd/dockhand/main.go
@@ -39,8 +39,9 @@ type MCPServerMetadata struct {
 
 // MCPServerPackageSpec defines the package to be containerized
 type MCPServerPackageSpec struct {
-	Package string `yaml:"package"`           // e.g., "@upstash/context7-mcp"
-	Version string `yaml:"version,omitempty"` // e.g., "1.0.14"
+	Package string   `yaml:"package"`           // e.g., "@upstash/context7-mcp"
+	Version string   `yaml:"version,omitempty"` // e.g., "1.0.14"
+	Args    []string `yaml:"args,omitempty"`    // Additional arguments for the package
 }
 
 // MCPServerProvenance contains supply chain provenance information
@@ -319,8 +320,8 @@ func generateDockerfile(ctx context.Context, spec *MCPServerSpec, customTag stri
 		protocolScheme,
 		"", // caCertPath - empty for now
 		imageTag,
-		[]string{}, // extraArgs
-		true,       // always dryRun to generate Dockerfile
+		spec.Spec.Args, // Pass args from spec if present
+		true,           // always dryRun to generate Dockerfile
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate Dockerfile for protocol scheme %s: %w", protocolScheme, err)

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -28,6 +28,9 @@ metadata:
 spec:
   package: "{package-identifier}"  # PyPI/npm name or Go module
   version: "{exact-version}"
+  args:                            # Optional: CLI arguments for the package
+    - "{arg1}"                     # Passed to the entrypoint command
+    - "{arg2}"
 
 provenance:
   repository_uri: "{github-url}"


### PR DESCRIPTION
## Summary

Implements dockyard-side support for build args as described in #189. This allows spec.yaml files to specify additional CLI arguments that are baked into the container entrypoint.

## Changes

- Added `args` field to `MCPServerPackageSpec` struct
- Updated `generateDockerfile()` to pass args to `BuildFromProtocolSchemeWithName`
- Updated documentation in README.md and docs/packaging.md with examples

## Implementation Details

The `args` field is optional and accepts an array of strings:

```yaml
spec:
  package: "@example/mcp-server"
  version: "1.0.0"
  args:
    - "start"
    - "--flag"
```

These arguments are passed to the toolhive `BuildFromProtocolSchemeWithName` function, which appends them to the container entrypoint. For example, with the above spec, the generated Dockerfile will have:

```dockerfile
ENTRYPOINT ["npx", "@example/mcp-server", "start", "--flag"]
```

## Benefits

- Required CLI arguments are baked into the container, preventing users from accidentally overwriting them
- Solves the issue where `thv run -- args` overwrites default args instead of appending
- Works seamlessly with the updated toolhive `BuildFromProtocolSchemeWithName` that now supports the `buildArgs` parameter

## Testing

Tested with local builds to verify args are correctly passed through to the generated Dockerfile.

Closes #189