### PR TITLE
feat: add start arg to launchdarkly spec

### DIFF
--- a/npx/launchdarkly-mcp-server/spec.yaml
+++ b/npx/launchdarkly-mcp-server/spec.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   package: "@launchdarkly/mcp-server"
   version: "0.4.2"
+  args:
+    - "start"
 
 provenance:
   repository_uri: "https://github.com/launchdarkly/mcp-server"


### PR DESCRIPTION
Moving the "start" arg from runtime to build-time.

Ref https://github.com/stacklok/toolhive-registry/pull/452

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>