### PR TITLE
Add pagerduty-mcp

### DIFF
--- a/uvx/pagerduty-mcp/spec.yaml
+++ b/uvx/pagerduty-mcp/spec.yaml
@@ -1,0 +1,23 @@
+# PagerDuty MCP Server Configuration
+# Official MCP server for PagerDuty integration
+# Package: https://pypi.org/project/pagerduty-mcp/
+# Repository: https://github.com/PagerDuty/pagerduty-mcp-server
+# Will build as: ghcr.io/stacklok/dockyard/uvx/pagerduty
+
+metadata:
+  name: pagerduty
+  description: "MCP server that integrates with PagerDuty to manage incidents, services, schedules, event orchestrations, and more"
+  protocol: uvx
+
+spec:
+  package: "pagerduty-mcp"
+  version: "0.9.2"
+
+provenance:
+  repository_uri: "https://github.com/PagerDuty/pagerduty-mcp-server"
+  repository_ref: "refs/heads/main"  # Using main branch as the primary development branch
+
+security:
+  allowed_issues:
+    - code: "TF001"
+      reason: "Data leak risk acceptable - incident management requires sharing operational data with responders and creating public status updates. Write operations are disabled by default, requiring explicit opt-in with --enable-write-tools flag."


### PR DESCRIPTION
This is the official PagerDuty local MCP server.

Confirmed that the image starts successfully with ToolHive.

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>