### PR TITLE
feat(tavily-mcp): enable security scanning with mock_env

### DIFF
--- a/npx/tavily-mcp/spec.yaml
+++ b/npx/tavily-mcp/spec.yaml
@@ -19,5 +19,9 @@ provenance:
 
 # Security configuration
 security:
-  # Server requires TAVILY_API_KEY to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: TAVILY_API_KEY
+      value: "mock-tavily-api-key-for-scanning"
+      description: "Tavily API key - mock value for security scanning"
+  allowed_issues: []


### PR DESCRIPTION
## Summary

- Enables security scanning for tavily-mcp by providing mock environment variables
- Removes `insecure_ignore: true` flag

## Changes

Replaces `insecure_ignore: true` with `mock_env` configuration that provides a placeholder `TAVILY_API_KEY`. This allows mcp-scanner to start the server and discover its tools for security analysis.

## Test plan

- [ ] CI security scan passes for tavily-mcp
- [ ] Verify 5 tools are scanned (tavily_search, tavily_extract, tavily_crawl, tavily_map, tavily_research)

## Local test results

```
✅ No security issues found in tavily-mcp (5 tools scanned)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)