### PR TITLE
feat(context7): enable security scanning with mock_env

### DIFF
--- a/npx/context7/spec.yaml
+++ b/npx/context7/spec.yaml
@@ -21,8 +21,11 @@ provenance:
 
 # Security allowlist for known false positives
 security:
-  # Server requires CONTEXT7_API_KEY to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: CONTEXT7_API_KEY
+      value: "mock-context7-api-key-for-scanning"
+      description: "Context7 API key - mock value for security scanning"
   allowed_issues:
     - code: "AITech-1.1"
       reason: |


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for CONTEXT7_API_KEY
- This allows the security scanner to start the server and analyze its tools
- Keeps existing `allowed_issues` for AITech-1.1 false positives (coercive language patterns in tool descriptions)

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers 2 tools, finds expected AITech-1.1 issues
- [ ] CI security scan should pass with the allowed_issues configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)