### PR TITLE
feat(notion): enable security scanning with mock_env

### DIFF
--- a/npx/notion/spec.yaml
+++ b/npx/notion/spec.yaml
@@ -20,8 +20,11 @@ provenance:
 
 # Optional: Security allowlist
 security:
-  # Server requires NOTION_TOKEN to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: NOTION_TOKEN
+      value: "ntn_mock_token_for_security_scanning_00000000000"
+      description: "Notion API token - mock value for security scanning"
   allowed_issues:
     - code: "AITech-8.2"
       reason: |


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for NOTION_TOKEN
- This allows the security scanner to start the server and analyze its 22 tools
- Keeps existing `allowed_issues` for AITech-8.2 and AITech-9.1 (expected data leak and destructive flows for Notion integration)

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers 22 tools, all pass YARA analysis
- [ ] CI security scan should pass with the allowed_issues configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)