### PR TITLE
feat(magic-mcp): enable security scanning with mock_env

### DIFF
--- a/npx/magic-mcp/spec.yaml
+++ b/npx/magic-mcp/spec.yaml
@@ -19,6 +19,9 @@ provenance:
 
 # Security allowlist for known acceptable issues
 security:
-  # Server requires API_KEY (21st.dev Magic) to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: API_KEY
+      value: "mock-21st-dev-api-key-for-scanning"
+      description: "21st.dev Magic API key - mock value for security scanning"
   allowed_issues: []


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for API_KEY
- This allows the security scanner to start the server and analyze its 4 tools
- All tools pass YARA analysis with no issues

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers 4 tools, all pass YARA
- [ ] CI security scan should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)