### PR TITLE
feat(onchain-mcp): enable security scanning with mock_env

### DIFF
--- a/npx/onchain-mcp/spec.yaml
+++ b/npx/onchain-mcp/spec.yaml
@@ -20,6 +20,9 @@ provenance:
 # Optional: Security allowlist
 # No security issues currently flagged by scanner
 security:
-  # Server requires Bankless API credentials to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: BANKLESS_API_TOKEN
+      value: "mock-bankless-api-token-for-scanning"
+      description: "Bankless API token - mock value for security scanning"
   allowed_issues: []


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for BANKLESS_API_TOKEN
- This allows the security scanner to start the server and analyze its 10 blockchain tools
- All tools pass YARA analysis with no issues

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers 10 tools, all pass YARA
- [ ] CI security scan should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)