### PR TITLE
feat(mcp-server-circleci): enable security scanning with mock_env

### DIFF
--- a/npx/mcp-server-circleci/spec.yaml
+++ b/npx/mcp-server-circleci/spec.yaml
@@ -19,8 +19,11 @@ provenance:
 
 # Optional: Security allowlist
 security:
-  # Server requires CIRCLECI_API_TOKEN to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: CIRCLECI_TOKEN
+      value: "mock-circleci-token-for-scanning"
+      description: "CircleCI API token - mock value for security scanning"
   allowed_issues:
     - code: "AITech-1.1"
       reason: "CI/CD operations require specific terminology for pipeline control (run, rollback, rerun) that may trigger prompt injection warnings"


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for CIRCLECI_TOKEN
- This allows the security scanner to start the server and analyze its CI/CD tools
- Keeps existing `allowed_issues` for AITech-1.1, AITech-12.1, AITech-8.2, AITech-9.1

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers tools, finds expected AITech-1.1 issues
- [ ] CI security scan should pass with the allowed_issues configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)