### PR TITLE
feat(sentry-mcp-server): enable security scanning with mock_env

### DIFF
--- a/npx/sentry-mcp-server/spec.yaml
+++ b/npx/sentry-mcp-server/spec.yaml
@@ -19,8 +19,11 @@ provenance:
 
 # Security allowlist for known false positives
 security:
-  # Server requires SENTRY_ACCESS_TOKEN to start - cannot be scanned in CI
-  insecure_ignore: true
+  # Mock env vars allow security scanning without real credentials
+  mock_env:
+    - name: SENTRY_ACCESS_TOKEN
+      value: "sntrys_mock_token_for_security_scanning_00000"
+      description: "Sentry access token - mock value for security scanning"
   allowed_issues:
     - code: "AITech-9.1"
       reason: |


### PR DESCRIPTION
## Summary
- Replace `insecure_ignore: true` with `mock_env` configuration for SENTRY_ACCESS_TOKEN
- This allows the security scanner to start the server and analyze its debugging tools
- Keeps existing `allowed_issues` for AITech-9.1 (false positive on search_docs tool)

## Test plan
- [x] Verified scan works locally with mock env: scanner connects, discovers tools, passes YARA
- [ ] CI security scan should pass with the allowed_issues configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)