### PR TITLE
feat: add mcp-searxng server

### DIFF
--- a/npx/mcp-searxng/spec.yaml
+++ b/npx/mcp-searxng/spec.yaml
@@ -1,0 +1,25 @@
+---
+# SearXNG MCP Server Configuration
+# MCP server for SearXNG search engine integration
+# Package: https://www.npmjs.com/package/mcp-searxng
+# Repository: https://github.com/ihor-sokoliuk/mcp-searxng
+# Will build as: ghcr.io/stacklok/dockyard/npx/mcp-searxng:0.8.0
+
+metadata:
+  name: mcp-searxng
+  description: "MCP server for SearXNG search engine integration"
+  protocol: npx
+
+spec:
+  package: "mcp-searxng"
+  version: "0.8.0"
+
+security:
+  mock_env:
+    - name: SEARXNG_URL
+      value: "http://example.com"
+      description: "searxng url - mock value for security scanning"
+
+provenance:
+  repository_uri: "https://github.com/ihor-sokoliuk/mcp-searxng"
+  repository_ref: "refs/tags/v0.8.0"


### PR DESCRIPTION
## Summary

Add packaging for mcp-searxng MCP server to Dockyard.

MCP server for SearXNG search engine integration. Enables AI assistants to perform web searches using a self-hosted SearXNG instance.

- **Package:** https://www.npmjs.com/package/mcp-searxng
- **Repository:** https://github.com/ihor-sokoliuk/mcp-searxng
- **Version:** 0.8.0

Split from #362 per maintainer request.

**Note:** Security scan may require environment variable configuration per maintainer's comment on #362.