### PR TITLE
fix: use workflow_run for MCP scan PR comments to support fork PRs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -173,7 +173,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -519,164 +518,21 @@ jobs:
             echo "- **Status**: ✅ Built (not pushed - PR)" >> $GITHUB_STEP_SUMMARY
           fi
 
-  mcp-scan-report:
-    needs: mcp-security-scan
+  # Save PR number as artifact for the mcp-scan-report workflow.
+  # This is needed because workflow_run doesn't reliably provide PR info for fork PRs.
+  save-pr-number:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && always()
-    permissions:
-      pull-requests: write
+    if: github.event_name == 'pull_request'
     steps:
-      - name: Download all scan results
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          pattern: mcp-scan-*
-          path: scan-artifacts
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
-      - name: Comment PR with scan results
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      - name: Upload PR number
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            
-            let comment = '## 🔒 MCP Security Scan Results\n\n';
-            let hasAnyIssues = false;
-            let totalServersScanned = 0;
-            let totalVulnerabilities = 0;
-            
-            // Find all scan summary files in the scan-artifacts directory
-            const summaryFiles = [];
-            const artifactsDir = 'scan-artifacts';
-            
-            // Debug: List all files in current directory
-            console.log('Current directory contents:', fs.readdirSync('.'));
-            
-            if (fs.existsSync(artifactsDir)) {
-              console.log('Artifacts directory exists');
-              const artifactDirs = fs.readdirSync(artifactsDir);
-              console.log('Artifact directories:', artifactDirs);
-              
-              // Check each item in the artifacts directory
-              for (const item of artifactDirs) {
-                const itemPath = path.join(artifactsDir, item);
-                const stat = fs.statSync(itemPath);
-                
-                if (stat.isDirectory()) {
-                  // Look for scan-summary.json in subdirectory
-                  const summaryFile = path.join(itemPath, 'scan-summary.json');
-                  if (fs.existsSync(summaryFile)) {
-                    summaryFiles.push(summaryFile);
-                    console.log('Found summary file in directory:', summaryFile);
-                  } else {
-                    console.log(`No scan-summary.json in ${itemPath}, contents:`, fs.readdirSync(itemPath));
-                  }
-                } else if (stat.isFile() && item === 'scan-summary.json') {
-                  // The file is directly in the artifacts directory
-                  summaryFiles.push(itemPath);
-                  console.log('Found summary file directly:', itemPath);
-                }
-              }
-            } else {
-              console.log('Artifacts directory does not exist');
-            }
-            
-            console.log('Total summary files found:', summaryFiles.length);
-            
-            if (summaryFiles.length === 0) {
-              comment += '⚠️ No MCP servers were scanned in this PR.\n';
-            } else {
-              for (const file of summaryFiles) {
-                try {
-                  const summary = JSON.parse(fs.readFileSync(file, 'utf8'));
-                  totalServersScanned++;
-                  
-                  if (summary.status === 'passed') {
-                    comment += `### ✅ ${summary.server}\n`;
-                    comment += `- **Status**: Passed\n`;
-                    comment += `- **Tools scanned**: ${summary.tools_scanned || 0}\n`;
-                    comment += `- **Result**: No security issues detected\n\n`;
-                  } else if (summary.status === 'failed') {
-                    hasAnyIssues = true;
-                    totalVulnerabilities += summary.blocking_count || 0;
-                    comment += `### ❌ ${summary.server}\n`;
-                    comment += `- **Status**: Failed\n`;
-                    comment += `- **Tools scanned**: ${summary.tools_scanned || 0}\n`;
-                    comment += `- **Vulnerabilities found**: ${summary.blocking_count || 0}\n`;
-                    comment += '\n**Security issues detected:**\n';
-                    
-                    if (summary.blocking_issues) {
-                      summary.blocking_issues.forEach(vuln => {
-                        comment += `- **[${vuln.code}]** ${vuln.message}\n`;
-                      });
-                    }
-                    
-                    // Also show allowed issues if any
-                    if (summary.allowed_issues && summary.allowed_issues.length > 0) {
-                      comment += '\n**Allowed issues (not blocking):**\n';
-                      summary.allowed_issues.forEach(vuln => {
-                        comment += `- **[${vuln.code}]** ${vuln.message} _(Allowed: ${vuln.allowed_reason})_\n`;
-                      });
-                    }
-                    comment += '\n';
-                  } else if (summary.status === 'warning') {
-                    comment += `### ⚠️ ${summary.server}\n`;
-                    comment += `- **Status**: Warning\n`;
-                    comment += `- **Message**: ${summary.message}\n\n`;
-                  } else {
-                    comment += `### ⚠️ ${summary.server}\n`;
-                    comment += `- **Status**: Error\n`;
-                    comment += `- **Message**: ${summary.message || 'Unknown error'}\n\n`;
-                  }
-                } catch (error) {
-                  console.error(`Error parsing ${file}:`, error);
-                  comment += `### ⚠️ Error parsing scan results\n`;
-                  comment += `Could not parse ${file}: ${error.message}\n\n`;
-                }
-              }
-              
-              // Add summary
-              if (totalServersScanned > 0) {
-                comment += '---\n';
-                comment += `**Summary**: Scanned ${totalServersScanned} MCP server(s)`;
-                if (hasAnyIssues) {
-                  comment += `, found ${totalVulnerabilities} security issue(s).\n\n`;
-                  comment += '⚠️ **Action Required**: Security issues were detected. Please review and address them before merging.\n';
-                } else {
-                  comment += ', all passed security checks. ✅\n';
-                }
-              }
-            }
-            
-            // Find and update or create comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' && comment.body.includes('MCP Security Scan Results')
-            );
-            
-            if (botComment) {
-              // Update existing comment
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment
-              });
-              console.log(`Updated existing comment #${botComment.id}`);
-            } else {
-              // Create new comment
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: comment
-              });
-              console.log('Created new comment');
-            }
+          name: pr-number
+          path: pr-number.txt
+          retention-days: 5
 
   summary:
     needs: [discover-configs, verify-provenance, mcp-security-scan, build-containers]

--- a/.github/workflows/mcp-scan-report.yml
+++ b/.github/workflows/mcp-scan-report.yml
@@ -1,0 +1,176 @@
+# This workflow runs in the context of the base repository and has write access
+# to post PR comments, even for PRs from forks. It triggers after the main
+# build-containers workflow completes and downloads scan result artifacts.
+name: MCP Scan Report
+
+on:
+  workflow_run:
+    workflows: ["Build MCP Server Containers"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  mcp-scan-report:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR number artifact
+        id: pr-number
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: read-pr
+        run: |
+          PR_NUMBER=$(cat pr-number.txt)
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "PR number: $PR_NUMBER"
+
+      - name: Download scan results
+        id: scan-results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: mcp-scan-*
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: scan-artifacts
+        continue-on-error: true
+
+      - name: Comment PR with scan results
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const prNumber = parseInt('${{ steps.read-pr.outputs.pr_number }}');
+            console.log('Commenting on PR:', prNumber);
+
+            let comment = '## 🔒 MCP Security Scan Results\n\n';
+            let hasAnyIssues = false;
+            let totalServersScanned = 0;
+            let totalVulnerabilities = 0;
+
+            // Find all scan summary files in the scan-artifacts directory
+            const summaryFiles = [];
+            const artifactsDir = 'scan-artifacts';
+
+            if (fs.existsSync(artifactsDir)) {
+              const artifactDirs = fs.readdirSync(artifactsDir);
+              console.log('Artifact contents:', artifactDirs);
+
+              for (const item of artifactDirs) {
+                const itemPath = path.join(artifactsDir, item);
+                const stat = fs.statSync(itemPath);
+
+                if (stat.isDirectory()) {
+                  const summaryFile = path.join(itemPath, 'scan-summary.json');
+                  if (fs.existsSync(summaryFile)) {
+                    summaryFiles.push(summaryFile);
+                    console.log('Found summary file in directory:', summaryFile);
+                  }
+                } else if (stat.isFile() && item === 'scan-summary.json') {
+                  summaryFiles.push(itemPath);
+                  console.log('Found summary file directly:', itemPath);
+                }
+              }
+            }
+
+            console.log('Total summary files found:', summaryFiles.length);
+
+            if (summaryFiles.length === 0) {
+              comment += '⚠️ No MCP servers were scanned in this PR.\n';
+            } else {
+              for (const file of summaryFiles) {
+                try {
+                  const summary = JSON.parse(fs.readFileSync(file, 'utf8'));
+                  totalServersScanned++;
+
+                  if (summary.status === 'passed') {
+                    comment += `### ✅ ${summary.server}\n`;
+                    comment += `- **Status**: Passed\n`;
+                    comment += `- **Tools scanned**: ${summary.tools_scanned || 0}\n`;
+                    comment += `- **Result**: No security issues detected\n\n`;
+                  } else if (summary.status === 'failed') {
+                    hasAnyIssues = true;
+                    totalVulnerabilities += summary.blocking_count || 0;
+                    comment += `### ❌ ${summary.server}\n`;
+                    comment += `- **Status**: Failed\n`;
+                    comment += `- **Tools scanned**: ${summary.tools_scanned || 0}\n`;
+                    comment += `- **Vulnerabilities found**: ${summary.blocking_count || 0}\n`;
+                    comment += '\n**Security issues detected:**\n';
+
+                    if (summary.blocking_issues) {
+                      summary.blocking_issues.forEach(vuln => {
+                        comment += `- **[${vuln.code}]** ${vuln.message}\n`;
+                      });
+                    }
+
+                    if (summary.allowed_issues && summary.allowed_issues.length > 0) {
+                      comment += '\n**Allowed issues (not blocking):**\n';
+                      summary.allowed_issues.forEach(vuln => {
+                        comment += `- **[${vuln.code}]** ${vuln.message} _(Allowed: ${vuln.allowed_reason})_\n`;
+                      });
+                    }
+                    comment += '\n';
+                  } else if (summary.status === 'warning') {
+                    comment += `### ⚠️ ${summary.server}\n`;
+                    comment += `- **Status**: Warning\n`;
+                    comment += `- **Message**: ${summary.message}\n\n`;
+                  } else {
+                    comment += `### ⚠️ ${summary.server}\n`;
+                    comment += `- **Status**: Error\n`;
+                    comment += `- **Message**: ${summary.message || 'Unknown error'}\n\n`;
+                  }
+                } catch (error) {
+                  console.error(`Error parsing ${file}:`, error);
+                  comment += `### ⚠️ Error parsing scan results\n`;
+                  comment += `Could not parse ${file}: ${error.message}\n\n`;
+                }
+              }
+
+              if (totalServersScanned > 0) {
+                comment += '---\n';
+                comment += `**Summary**: Scanned ${totalServersScanned} MCP server(s)`;
+                if (hasAnyIssues) {
+                  comment += `, found ${totalVulnerabilities} security issue(s).\n\n`;
+                  comment += '⚠️ **Action Required**: Security issues were detected. Please review and address them before merging.\n';
+                } else {
+                  comment += ', all passed security checks. ✅\n';
+                }
+              }
+            }
+
+            // Find and update or create comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('MCP Security Scan Results')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+              console.log(`Updated existing comment #${botComment.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+              console.log('Created new comment');
+            }


### PR DESCRIPTION
## Summary
- The `mcp-scan-report` job was failing with a 403 "Resource not accessible by integration" error when PRs came from forks, because GitHub restricts the `GITHUB_TOKEN` to read-only on `pull_request` events from forks
- Moved the PR commenting logic to a separate `mcp-scan-report.yml` workflow triggered by `workflow_run`, which runs in the base repo context and has write permissions
- Added a `save-pr-number` job to pass the PR number via artifact, since `workflow_run` doesn't reliably provide PR info for fork PRs

## Test plan
- [ ] Verify the new workflow file is syntactically valid (CI should catch this)
- [ ] Test with a same-repo PR to confirm comments still work
- [ ] Test with a fork PR to confirm the 403 error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)