### PR TITLE
Add Global Chat MCP server

### DIFF
--- a/npx/global-chat-mcp-server/spec.yaml
+++ b/npx/global-chat-mcp-server/spec.yaml
@@ -1,0 +1,18 @@
+# Global Chat MCP Server Configuration
+# Cross-protocol AI agent discovery — search, validate, and register agents
+# Package: https://www.npmjs.com/package/@global-chat/mcp-server
+# Repository: https://github.com/pumanitro/global-chat
+# Will build as: ghcr.io/stacklok/dockyard/npx/global-chat-mcp-server:0.1.1
+
+metadata:
+  name: global-chat-mcp-server
+  description: "Cross-protocol AI agent discovery for MCP, A2A, and agents.txt"
+  protocol: npx
+
+spec:
+  package: "@global-chat/mcp-server"
+  version: "0.1.1"
+
+provenance:
+  repository_uri: "https://github.com/pumanitro/global-chat"
+  repository_ref: "refs/tags/v0.1.1"


### PR DESCRIPTION
## Summary

Adds the [Global Chat MCP server](https://www.npmjs.com/package/@global-chat/mcp-server) to the dockyard for containerized distribution.

**Global Chat** is a cross-protocol AI agent discovery platform. The MCP server provides tools to search agents across MCP, A2A, and agents.txt registries, validate agents.txt files, list registered agents, and register new agents.

**Tools provided:**
- `validate_agents_txt` — Validate an agents.txt file by URL or raw content
- `list_agents` — List all registered AI agents, optionally filtered by type
- `search_agents` — Search agents by name, description, or capabilities
- `register_agent` — Register a new AI agent in the directory

## References

- npm: [@global-chat/mcp-server](https://www.npmjs.com/package/@global-chat/mcp-server)
- Repository: [pumanitro/global-chat](https://github.com/pumanitro/global-chat)
- Website: [global-chat.io](https://global-chat.io)