### PR TITLE
feat(skills): gate publishing on Cisco skill-scanner + SCAI attestation

### DIFF
--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -7,6 +7,9 @@ on:
       - 'skills/**/*.yaml'
       - 'cmd/dockhand/**'
       - 'internal/skills/**'
+      - 'scripts/skill-scan/**'
+      - '.github/workflows/build-skills.yml'
+      - '.github/workflows/skill-scan-report.yml'
       - 'go.mod'
       - 'go.sum'
   pull_request:
@@ -15,6 +18,9 @@ on:
       - 'skills/**/*.yaml'
       - 'cmd/dockhand/**'
       - 'internal/skills/**'
+      - 'scripts/skill-scan/**'
+      - '.github/workflows/build-skills.yml'
+      - '.github/workflows/skill-scan-report.yml'
       - 'go.mod'
       - 'go.sum'
   workflow_dispatch:
@@ -31,6 +37,7 @@ jobs:
       contents: read
     outputs:
       changed-configs: ${{ steps.find-configs.outputs.changed-configs }}
+      scan-configs: ${{ steps.find-configs.outputs.scan-configs }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -49,48 +56,58 @@ jobs:
           if [ -z "$all_configs" ]; then
             echo "No skill configurations found"
             echo "changed-configs=[]" >> $GITHUB_OUTPUT
+            echo "scan-configs=[]" >> $GITHUB_OUTPUT
             exit 0
           fi
 
           if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             configs_to_build="$all_configs"
+            configs_to_scan="$all_configs"
             echo "Manual trigger - building all skill configurations"
           elif [ "$EVENT_NAME" == "pull_request" ]; then
             changed_files=$(git diff --name-only origin/"$BASE_REF"...HEAD)
             configs_to_build=""
+            configs_to_scan=""
 
+            # Scan only specs that actually changed; build the superset below.
             for config in $all_configs; do
               config_dir=$(dirname "$config")
               if echo "$changed_files" | grep -q "^$config$" || echo "$changed_files" | grep -q "^$config_dir/"; then
                 configs_to_build="$configs_to_build$config"$'\n'
+                configs_to_scan="$configs_to_scan$config"$'\n'
               fi
             done
 
-            # If dockhand source, internal/skills, go.mod, or go.sum changed, rebuild all
-            if echo "$changed_files" | grep -E "(cmd/dockhand/|internal/skills/|go\.mod|go\.sum)"; then
-              echo "Core files changed - rebuilding all skill configurations"
+            # If core build inputs changed, rebuild all skills — but only scan specs that truly changed.
+            if echo "$changed_files" | grep -E "(cmd/dockhand/|internal/skills/|scripts/skill-scan/|\.github/workflows/build-skills\.yml|go\.mod|go\.sum)"; then
+              echo "Core files changed - rebuilding all skill configurations (scan only changed specs)"
               configs_to_build="$all_configs"
             fi
           else
             changed_files=$(git diff --name-only HEAD~1..HEAD)
             configs_to_build=""
+            configs_to_scan=""
 
             for config in $all_configs; do
               config_dir=$(dirname "$config")
               if echo "$changed_files" | grep -q "^$config$" || echo "$changed_files" | grep -q "^$config_dir/"; then
                 configs_to_build="$configs_to_build$config"$'\n'
+                configs_to_scan="$configs_to_scan$config"$'\n'
               fi
             done
 
-            if echo "$changed_files" | grep -E "(cmd/dockhand/|internal/skills/|go\.mod|go\.sum)"; then
-              echo "Core files changed - rebuilding all skill configurations"
+            if echo "$changed_files" | grep -E "(cmd/dockhand/|internal/skills/|scripts/skill-scan/|\.github/workflows/build-skills\.yml|go\.mod|go\.sum)"; then
+              echo "Core files changed - rebuilding all skill configurations (scan only changed specs)"
               configs_to_build="$all_configs"
             fi
           fi
 
           configs_json=$(echo "$configs_to_build" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
+          scan_configs_json=$(echo "$configs_to_scan" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
           echo "changed-configs=$configs_json" >> $GITHUB_OUTPUT
+          echo "scan-configs=$scan_configs_json" >> $GITHUB_OUTPUT
           echo "Skill configurations to build: $configs_json"
+          echo "Skill configurations to scan: $scan_configs_json"
 
   validate-skills:
     needs: discover-skill-configs
@@ -121,11 +138,131 @@ jobs:
           echo "Validating skill: $CONFIG_FILE"
           /tmp/dockhand validate-skill --config "$CONFIG_FILE"
 
+  skill-security-scan:
+    needs: discover-skill-configs
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: ${{ needs.discover-skill-configs.outputs.scan-configs != '[]' }}
+    strategy:
+      matrix:
+        config: ${{ fromJson(needs.discover-skill-configs.outputs.scan-configs) }}
+      fail-fast: false
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install yq
+        uses: mikefarah/yq@5a7e72a743649b1b3a47d1a1d8214f3453173c51 # v4.52.4
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.13'
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        id: install-deps
+        run: |
+          uv pip install --system -r scripts/skill-scan/requirements.txt
+          skill-scanner --version || true
+          SCANNER_VERSION=$(uv pip show cisco-ai-skill-scanner | grep "^Version:" | cut -d' ' -f2)
+          echo "scanner_version=$SCANNER_VERSION" >> $GITHUB_OUTPUT
+          echo "Installed skill-scanner version: $SCANNER_VERSION"
+
+      - name: Extract metadata from config
+        id: meta
+        env:
+          CONFIG_FILE: ${{ matrix.config }}
+        run: |
+          skill_name=$(echo "$CONFIG_FILE" | cut -d'/' -f2)
+          echo "skill_name=$skill_name" >> $GITHUB_OUTPUT
+          echo "config_file=$CONFIG_FILE" >> $GITHUB_OUTPUT
+
+          repository=$(yq '.spec.repository' "$CONFIG_FILE")
+          ref=$(yq '.spec.ref' "$CONFIG_FILE")
+          skill_path=$(yq '.spec.path // ""' "$CONFIG_FILE")
+          echo "repository=$repository" >> $GITHUB_OUTPUT
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+          echo "skill_path=$skill_path" >> $GITHUB_OUTPUT
+
+      - name: Check out skill source
+        id: skill-src
+        env:
+          SKILL_REPO: ${{ steps.meta.outputs.repository }}
+          SKILL_REF: ${{ steps.meta.outputs.ref }}
+          SKILL_PATH: ${{ steps.meta.outputs.skill_path }}
+          SKILL_NAME: ${{ steps.meta.outputs.skill_name }}
+        run: |
+          workdir="/tmp/skill-scan-${SKILL_NAME}"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          git clone --filter=tree:0 --no-checkout --quiet "$SKILL_REPO" "$workdir/repo"
+          git -C "$workdir/repo" checkout --quiet "$SKILL_REF"
+          if [ -n "$SKILL_PATH" ]; then
+            src_dir="$workdir/repo/$SKILL_PATH"
+          else
+            src_dir="$workdir/repo"
+          fi
+          if [ ! -d "$src_dir" ]; then
+            echo "Error: skill source directory not found at $src_dir" >&2
+            exit 1
+          fi
+          echo "source_dir=$src_dir" >> $GITHUB_OUTPUT
+
+      - name: Run skill security scan
+        id: scan
+        env:
+          SKILL_SCANNER_USE_LLM: ${{ vars.SKILL_SCANNER_USE_LLM || 'false' }}
+          SKILL_SCANNER_LLM_API_KEY: ${{ secrets.SKILL_SCANNER_LLM_API_KEY }}
+          SKILL_NAME: ${{ steps.meta.outputs.skill_name }}
+          SOURCE_DIR: ${{ steps.skill-src.outputs.source_dir }}
+          CONFIG_FILE: ${{ matrix.config }}
+          SCANNER_VERSION: ${{ steps.install-deps.outputs.scanner_version }}
+        run: |
+          scan_output="skill-scan-${SKILL_NAME}.json"
+          scan_stderr="skill-scan-${SKILL_NAME}.stderr"
+
+          python3 scripts/skill-scan/run_scan.py \
+            --source "$SOURCE_DIR" \
+            --output "$scan_output" \
+            2> "$scan_stderr" || true
+
+          if [ -s "$scan_stderr" ]; then
+            echo "Scanner stderr output:"
+            cat "$scan_stderr"
+          fi
+
+          # process_scan_results.py exits 1 on unallowlisted findings — that fails the job.
+          python3 scripts/skill-scan/process_scan_results.py \
+            "$scan_output" \
+            "$SKILL_NAME" \
+            "$CONFIG_FILE" \
+            > scan-summary.json
+
+          echo "$SCANNER_VERSION" > scanner-version.txt
+
+      - name: Upload scan results
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: skill-scan-${{ steps.meta.outputs.skill_name }}
+          path: |
+            skill-scan-${{ steps.meta.outputs.skill_name }}.json
+            scan-summary.json
+            scanner-version.txt
+          retention-days: 30
+
   build-skill-artifacts:
-    needs: [discover-skill-configs, validate-skills]
+    needs: [discover-skill-configs, validate-skills, skill-security-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' }}
+    if: ${{ needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' && (needs.skill-security-scan.result == 'success' || needs.skill-security-scan.result == 'skipped') }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-skill-configs.outputs.changed-configs) }}
@@ -272,6 +409,60 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      - name: Download skill security scan results
+        id: download-scan
+        if: github.event_name != 'pull_request' && steps.build.outputs.digest != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: skill-scan-${{ steps.meta.outputs.skill_name }}
+          path: /tmp/skill-scan-results
+        continue-on-error: false
+
+      - name: Create security scan attestation (SCAI format)
+        if: github.event_name != 'pull_request' && steps.build.outputs.digest != ''
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_NAME: ${{ steps.meta.outputs.image_name }}
+          CONFIG_FILE: ${{ matrix.config }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          SERVER_URL: ${{ github.server_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          SCANNER_VERSION=""
+          if [ -f /tmp/skill-scan-results/scanner-version.txt ]; then
+            SCANNER_VERSION=$(tr -d '\n' < /tmp/skill-scan-results/scanner-version.txt)
+            echo "Scanner version: $SCANNER_VERSION"
+          fi
+
+          python3 scripts/skill-scan/generate_scai_attestation.py \
+            /tmp/skill-scan-results/scan-summary.json \
+            "$IMAGE_NAME" \
+            "$DIGEST" \
+            --config-file "$CONFIG_FILE" \
+            --commit-sha "$COMMIT_SHA" \
+            --run-id "$RUN_ID" \
+            --run-url "${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}" \
+            --producer-uri "${SERVER_URL}/${REPO}" \
+            --scanner-version "$SCANNER_VERSION" \
+            --scanner-uri "https://github.com/cisco-ai-defense/skill-scanner" \
+            --validate \
+            --output /tmp/skill-scai.json
+
+          echo "Generated SCAI attestation:"
+          cat /tmp/skill-scai.json
+
+          cosign attest --yes \
+            --predicate /tmp/skill-scai.json \
+            --type https://in-toto.io/attestation/scai/v0.3 \
+            "${IMAGE_NAME}@${DIGEST}"
+
+          ATTRIBUTE=$(python3 -c "import json,sys;print(json.load(open('/tmp/skill-scai.json'))['predicate']['attributes'][0]['attribute'])")
+          echo "SCAI security scan attestation created (${ATTRIBUTE})" >> $GITHUB_STEP_SUMMARY
+          rm -f /tmp/skill-scai.json
+
       - name: Build summary
         env:
           SKILL_NAME: ${{ steps.meta.outputs.skill_name }}
@@ -295,8 +486,25 @@ jobs:
             echo "| Provenance | Attested (SLSA) |" >> $GITHUB_STEP_SUMMARY
           fi
 
+  save-pr-number:
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: skill-pr-number
+          path: pr-number.txt
+          retention-days: 5
+
   summary:
-    needs: [discover-skill-configs, validate-skills, build-skill-artifacts]
+    needs: [discover-skill-configs, validate-skills, skill-security-scan, build-skill-artifacts]
     runs-on: ubuntu-latest
     if: always()
     permissions:
@@ -305,7 +513,9 @@ jobs:
       - name: Build summary
         env:
           CONFIGS: ${{ needs.discover-skill-configs.outputs.changed-configs }}
+          SCAN_CONFIGS: ${{ needs.discover-skill-configs.outputs.scan-configs }}
           VALIDATE_RESULT: ${{ needs.validate-skills.result }}
+          SCAN_RESULT: ${{ needs.skill-security-scan.result }}
           BUILD_RESULT: ${{ needs.build-skill-artifacts.result }}
         run: |
           echo "## Skill Build Pipeline Summary" >> $GITHUB_STEP_SUMMARY
@@ -314,5 +524,7 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| Trigger | ${{ github.event_name }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Skills to build | $(echo "$CONFIGS" | jq '. | length') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Skills to scan | $(echo "$SCAN_CONFIGS" | jq '. | length') |" >> $GITHUB_STEP_SUMMARY
           echo "| Validation | ${VALIDATE_RESULT} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Security scan | ${SCAN_RESULT} |" >> $GITHUB_STEP_SUMMARY
           echo "| Build | ${BUILD_RESULT} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/skill-scan-report.yml
+++ b/.github/workflows/skill-scan-report.yml
@@ -1,0 +1,172 @@
+# Runs in the base repository context so it can comment on PRs from forks.
+# Triggered after Build Skill Artifacts completes; downloads scan artifacts
+# and upserts a single "Skill Security Scan Results" PR comment.
+name: Skill Scan Report
+
+on:
+  workflow_run:
+    workflows: ["Build Skill Artifacts"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  skill-scan-report:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR number artifact
+        id: pr-number
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: skill-pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: read-pr
+        run: |
+          PR_NUMBER=$(cat pr-number.txt)
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "PR number: $PR_NUMBER"
+
+      - name: Download scan results
+        id: scan-results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: skill-scan-*
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: scan-artifacts
+        continue-on-error: true
+
+      - name: Comment PR with scan results
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const prNumber = parseInt('${{ steps.read-pr.outputs.pr_number }}');
+            console.log('Commenting on PR:', prNumber);
+
+            let comment = '## 🛡️ Skill Security Scan Results\n\n';
+            let hasAnyIssues = false;
+            let totalSkillsScanned = 0;
+            let totalBlocking = 0;
+
+            const summaryFiles = [];
+            const artifactsDir = 'scan-artifacts';
+
+            if (fs.existsSync(artifactsDir)) {
+              for (const item of fs.readdirSync(artifactsDir)) {
+                const itemPath = path.join(artifactsDir, item);
+                const stat = fs.statSync(itemPath);
+                if (stat.isDirectory()) {
+                  const summaryFile = path.join(itemPath, 'scan-summary.json');
+                  if (fs.existsSync(summaryFile)) summaryFiles.push(summaryFile);
+                } else if (stat.isFile() && item === 'scan-summary.json') {
+                  summaryFiles.push(itemPath);
+                }
+              }
+            }
+
+            if (summaryFiles.length === 0) {
+              comment += '⚠️ No skills were scanned in this PR.\n';
+            } else {
+              for (const file of summaryFiles) {
+                try {
+                  const summary = JSON.parse(fs.readFileSync(file, 'utf8'));
+                  totalSkillsScanned++;
+                  const name = summary.skill || 'unknown';
+
+                  if (summary.status === 'passed') {
+                    comment += `### ✅ ${name}\n`;
+                    comment += `- **Status**: Passed\n`;
+                    comment += `- **Findings**: ${summary.findings_count || 0}\n`;
+                    if (summary.allowed_issues && summary.allowed_issues.length > 0) {
+                      comment += `- **Allowed (not blocking)**: ${summary.allowed_count}\n`;
+                      for (const issue of summary.allowed_issues) {
+                        comment += `  - \`${issue.code}\` _(Allowed: ${issue.allowed_reason})_\n`;
+                      }
+                    }
+                    comment += '\n';
+                  } else if (summary.status === 'failed') {
+                    hasAnyIssues = true;
+                    totalBlocking += summary.blocking_count || 0;
+                    comment += `### ❌ ${name}\n`;
+                    comment += `- **Status**: Failed\n`;
+                    comment += `- **Findings**: ${summary.findings_count || 0}\n`;
+                    comment += `- **Blocking**: ${summary.blocking_count || 0}\n\n`;
+                    comment += '**Blocking issues:**\n';
+                    if (summary.blocking_issues) {
+                      for (const issue of summary.blocking_issues) {
+                        const loc = issue.file_path
+                          ? ` _(${issue.file_path}${issue.line_number ? ':' + issue.line_number : ''})_`
+                          : '';
+                        comment += `- **[${issue.code}]** (${issue.severity}) ${issue.message}${loc}\n`;
+                      }
+                    }
+                    if (summary.allowed_issues && summary.allowed_issues.length > 0) {
+                      comment += '\n**Allowlisted (not blocking):**\n';
+                      for (const issue of summary.allowed_issues) {
+                        comment += `- \`${issue.code}\` _(Allowed: ${issue.allowed_reason})_\n`;
+                      }
+                    }
+                    comment += '\n';
+                  } else if (summary.status === 'warning') {
+                    comment += `### ⚠️ ${name}\n`;
+                    comment += `- **Status**: Warning\n`;
+                    comment += `- **Message**: ${summary.message}\n\n`;
+                  } else {
+                    comment += `### ⚠️ ${name}\n`;
+                    comment += `- **Status**: Error\n`;
+                    comment += `- **Message**: ${summary.message || 'Unknown error'}\n\n`;
+                  }
+                } catch (error) {
+                  console.error(`Error parsing ${file}:`, error);
+                  comment += `### ⚠️ Error parsing scan results\n`;
+                  comment += `Could not parse ${file}: ${error.message}\n\n`;
+                }
+              }
+
+              if (totalSkillsScanned > 0) {
+                comment += '---\n';
+                comment += `**Summary**: Scanned ${totalSkillsScanned} skill(s)`;
+                if (hasAnyIssues) {
+                  comment += `, found ${totalBlocking} blocking issue(s).\n\n`;
+                  comment += '⚠️ **Action Required**: Review the blocking findings. Add a justified entry to the skill\'s `security.allowed_issues[]` in its `spec.yaml` if the finding is a false positive.\n';
+                } else {
+                  comment += ', all passed security checks. ✅\n';
+                }
+              }
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Skill Security Scan Results')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: comment
+              });
+              console.log(`Updated existing comment #${botComment.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+              console.log('Created new comment');
+            }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -360,6 +360,60 @@ tasks:
         fi
         build/dockhand build-skill --config "{{.SKILL_PATH}}/spec.yaml" $push_flag
 
+  scan-skill:
+    desc: "Run skill-scanner on a skill spec (clones source, scans, applies allowlist)"
+    summary: |
+      Clone a skill's source at the pinned ref, run Cisco AI Defense
+      skill-scanner on it, and apply the allowlist from the skill's spec.yaml.
+
+      Usage:
+        task scan-skill -- skills/claude-api
+
+      Environment variables:
+        SKILL_SCANNER_USE_BEHAVIORAL=true  - Enable AST/taint analysis
+        SKILL_SCANNER_USE_LLM=true         - Enable LLM analyzer
+        SKILL_SCANNER_LLM_API_KEY          - API key for LLM analyzer
+    requires:
+      vars: [CLI_ARGS]
+    vars:
+      SKILL_PATH: '{{.CLI_ARGS}}'
+      SKILL_NAME:
+        sh: echo "{{.SKILL_PATH}}" | cut -d'/' -f2
+      SPEC_FILE: '{{.SKILL_PATH}}/spec.yaml'
+      WORKDIR: '/tmp/skill-scan-{{.SKILL_NAME}}'
+    cmds:
+      - |
+        if [ ! -f "{{.SPEC_FILE}}" ]; then
+          echo "Error: spec.yaml not found at {{.SPEC_FILE}}"
+          exit 1
+        fi
+      - |
+        repository=$(yq '.spec.repository' "{{.SPEC_FILE}}")
+        ref=$(yq '.spec.ref' "{{.SPEC_FILE}}")
+        skill_path=$(yq '.spec.path // ""' "{{.SPEC_FILE}}")
+        rm -rf "{{.WORKDIR}}"
+        mkdir -p "{{.WORKDIR}}"
+        git clone --filter=tree:0 --no-checkout --quiet "$repository" "{{.WORKDIR}}/repo"
+        git -C "{{.WORKDIR}}/repo" checkout --quiet "$ref"
+        if [ -n "$skill_path" ]; then
+          src_dir="{{.WORKDIR}}/repo/$skill_path"
+        else
+          src_dir="{{.WORKDIR}}/repo"
+        fi
+        python3 scripts/skill-scan/run_scan.py \
+          --source "$src_dir" \
+          --output "{{.WORKDIR}}/scan.json"
+        python3 scripts/skill-scan/process_scan_results.py \
+          "{{.WORKDIR}}/scan.json" \
+          "{{.SKILL_NAME}}" \
+          "{{.SPEC_FILE}}"
+
+  scan-skill-setup:
+    desc: "Install cisco-ai-skill-scanner via uv"
+    cmds:
+      - uv tool install cisco-ai-skill-scanner
+      - skill-scanner --version || true
+
   build-help:
     desc: "Show help for build tasks"
     summary: |

--- a/scripts/skill-scan/README.md
+++ b/scripts/skill-scan/README.md
@@ -1,0 +1,102 @@
+# Skill Security Scanning Scripts
+
+Wrappers for [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)
+used by the `Build Skill Artifacts` workflow.
+
+## Scripts
+
+### run_scan.py
+
+Invokes `skill-scanner scan <source-dir> --format json` and writes the JSON
+report. Exits `0` regardless of findings — allowlist filtering happens in
+`process_scan_results.py`.
+
+```bash
+python3 scripts/skill-scan/run_scan.py \
+  --source /path/to/skill-source \
+  --output /tmp/skill-scan.json
+```
+
+Optional environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `SKILL_SCANNER_USE_BEHAVIORAL` | `true` enables `--use-behavioral` (AST taint tracking). |
+| `SKILL_SCANNER_USE_LLM` | `true` enables `--use-llm`. Requires `SKILL_SCANNER_LLM_API_KEY`. |
+| `SKILL_SCANNER_LLM_API_KEY` | API key for the LLM analyzer. |
+
+### process_scan_results.py
+
+Reads the scanner JSON, applies a two-tier allowlist (global + per-skill
+`spec.yaml`), and exits `1` when any unallowlisted finding exists. The
+`scan-summary.json` it prints to stdout is consumed by the SCAI attestation
+generator and the PR report workflow.
+
+```bash
+python3 scripts/skill-scan/process_scan_results.py \
+  /tmp/skill-scan.json claude-api skills/claude-api/spec.yaml \
+  > scan-summary.json
+```
+
+Allowlist entries live under `security.allowed_issues[]` in a skill's
+`spec.yaml`. Match by exact `rule_id` (specific) or by `category` (broader):
+
+```yaml
+security:
+  allowed_issues:
+    - rule_id: SOCIAL_ENG_ANTHROPIC_IMPERSONATION
+      reason: "claude-api is officially from Anthropic"
+    - category: social_engineering
+      reason: "trusted first-party skill"
+  insecure_ignore: false  # DO NOT use unless the scanner cannot run against this skill
+```
+
+Entries from `scripts/skill-scan/global_allowed_issues.yaml` apply to every
+skill. Start with per-skill entries first; promote to global only when a
+rule is globally a false positive across the catalog.
+
+### generate_scai_attestation.py
+
+Builds an in-toto SCAI predicate
+([spec](https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md))
+from a scan summary, targeting the OCI artifact digest. The CI workflow signs
+the result with `cosign attest --type https://in-toto.io/attestation/scai/v0.3`.
+
+```bash
+python3 scripts/skill-scan/generate_scai_attestation.py \
+  scan-summary.json \
+  ghcr.io/stacklok/dockyard/skills/claude-api \
+  sha256:0123... \
+  --config-file skills/claude-api/spec.yaml \
+  --commit-sha "$GITHUB_SHA" \
+  --run-id "$GITHUB_RUN_ID" \
+  --run-url "https://github.com/stacklok/dockyard/actions/runs/$GITHUB_RUN_ID" \
+  --producer-uri https://github.com/stacklok/dockyard \
+  --scanner-version 2.0.9 \
+  --validate \
+  --output /tmp/skill-scai.json
+```
+
+## Testing locally
+
+```bash
+# Install the scanner (one-time)
+uv tool install cisco-ai-skill-scanner
+
+# Clone the skill source the way CI does
+git clone --filter=tree:0 --no-checkout https://github.com/anthropics/skills /tmp/skill-src
+git -C /tmp/skill-src checkout "$(yq .spec.ref skills/claude-api/spec.yaml)"
+
+# Scan + process
+python3 scripts/skill-scan/run_scan.py \
+  --source /tmp/skill-src/skills/claude-api \
+  --output /tmp/skill-scan.json
+python3 scripts/skill-scan/process_scan_results.py \
+  /tmp/skill-scan.json claude-api skills/claude-api/spec.yaml
+```
+
+## See also
+
+- [Cisco AI Defense skill-scanner](https://github.com/cisco-ai-defense/skill-scanner)
+- Sibling pipeline: [`scripts/mcp-scan/`](../mcp-scan/README.md) — same SCAI
+  attestation + allowlist pattern applied to MCP servers.

--- a/scripts/skill-scan/generate_scai_attestation.py
+++ b/scripts/skill-scan/generate_scai_attestation.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Generate a SCAI attestation for a skill security scan.
+
+Follows the in-toto SCAI predicate specification:
+https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md
+
+Usage:
+    generate_scai_attestation.py <scan_summary_file> <image_name> <image_digest> \
+        --config-file <spec.yaml> --commit-sha <sha> --run-id <id> --run-url <url> \
+        --producer-uri <uri> [--scanner-version VERSION]
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+SCAI_PREDICATE_TYPE = "https://in-toto.io/attestation/scai/v0.3"
+INTOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+
+
+def compute_file_sha256(file_path: str) -> str:
+    sha256 = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def load_yaml(path: str) -> dict[str, Any]:
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def determine_attribute(status: str) -> str:
+    if status == "passed":
+        return "SKILL_SECURITY_SCAN_PASSED"
+    if status == "warning":
+        return "SKILL_SECURITY_SCAN_WARNING"
+    return "SKILL_SECURITY_SCAN_FAILED"
+
+
+def build_scai_attestation(
+    scan_summary: dict[str, Any],
+    scan_summary_path: str,
+    image_name: str,
+    image_digest: str,
+    config_file: str,
+    commit_sha: str,
+    run_id: str,
+    run_url: str,
+    producer_uri: str,
+    scanner_version: str | None = None,
+    scanner_uri: str | None = None,
+    source_repository: str | None = None,
+) -> dict[str, Any]:
+    analyzers = scan_summary.get("analyzers") or []
+    status = scan_summary.get("status", "unknown")
+    findings_count = scan_summary.get("findings_count", 0)
+    blocking_count = scan_summary.get("blocking_count", 0)
+    allowed_count = scan_summary.get("allowed_count", 0)
+
+    evidence_hash = compute_file_sha256(scan_summary_path)
+    scan_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    attribute = determine_attribute(status)
+
+    digest_value = image_digest
+    if digest_value.startswith("sha256:"):
+        digest_value = digest_value[7:]
+
+    conditions: dict[str, Any] = {
+        "scanner": "cisco-ai-skill-scanner",
+        "analyzers": analyzers,
+        "findingsCount": findings_count,
+        "blockingIssues": blocking_count,
+        "allowedIssues": allowed_count,
+        "scanDate": scan_date,
+        "configFile": config_file,
+    }
+    if scanner_version:
+        conditions["scannerVersion"] = scanner_version
+    if scanner_uri:
+        conditions["scannerUri"] = scanner_uri
+    if source_repository:
+        conditions["sourceRepository"] = source_repository
+    # Include run_id in the attribute conditions so the attestation can be
+    # traced back to the exact CI run even if run_url format changes.
+    if run_id:
+        conditions["runId"] = run_id
+
+    return {
+        "_type": INTOTO_STATEMENT_TYPE,
+        "subject": [
+            {
+                "name": image_name,
+                "digest": {"sha256": digest_value},
+            }
+        ],
+        "predicateType": SCAI_PREDICATE_TYPE,
+        "predicate": {
+            "attributes": [
+                {
+                    "attribute": attribute,
+                    "conditions": conditions,
+                    "evidence": {
+                        "name": "scan-summary.json",
+                        "digest": {"sha256": evidence_hash},
+                        "uri": run_url,
+                        "mediaType": "application/json",
+                    },
+                }
+            ],
+            "producer": {
+                "uri": producer_uri,
+                "name": "dockyard-ci",
+                "digest": {"gitCommit": commit_sha},
+            },
+        },
+    }
+
+
+def validate_attestation(att: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if att.get("_type") != INTOTO_STATEMENT_TYPE:
+        errors.append(f"Invalid _type: expected {INTOTO_STATEMENT_TYPE}")
+    if att.get("predicateType") != SCAI_PREDICATE_TYPE:
+        errors.append(f"Invalid predicateType: expected {SCAI_PREDICATE_TYPE}")
+    subjects = att.get("subject") or []
+    if not subjects:
+        errors.append("Missing subject")
+    for i, s in enumerate(subjects):
+        if not s.get("name"):
+            errors.append(f"Subject {i}: missing name")
+        if not s.get("digest"):
+            errors.append(f"Subject {i}: missing digest")
+    predicate = att.get("predicate") or {}
+    attributes = predicate.get("attributes") or []
+    if not attributes:
+        errors.append("Missing attributes in predicate")
+    for i, a in enumerate(attributes):
+        if not a.get("attribute"):
+            errors.append(f"Attribute {i}: missing attribute field")
+        evidence = a.get("evidence") or {}
+        if evidence and not (evidence.get("name") or evidence.get("uri") or evidence.get("digest")):
+            errors.append(f"Attribute {i}: evidence must have name, uri, or digest")
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate SCAI attestation for skill security scans"
+    )
+    parser.add_argument("scan_summary_file", help="Path to the scan summary JSON file")
+    parser.add_argument("image_name", help="Full OCI artifact name (no tag)")
+    parser.add_argument("image_digest", help="OCI artifact digest (sha256:...)")
+    parser.add_argument("--config-file", required=True, help="Path to the skill spec.yaml")
+    parser.add_argument("--commit-sha", required=True, help="Git commit SHA")
+    parser.add_argument("--run-id", required=True, help="GitHub Actions run ID")
+    parser.add_argument("--run-url", required=True, help="URL to the GitHub Actions run")
+    parser.add_argument(
+        "--producer-uri",
+        required=True,
+        help="Full URI of the attestation producer (e.g. https://github.com/stacklok/dockyard)",
+    )
+    parser.add_argument("--scanner-version", help="Version of the scanner (e.g. 2.0.9)")
+    parser.add_argument(
+        "--scanner-uri",
+        default="https://github.com/cisco-ai-defense/skill-scanner",
+        help="URI to the scanner source",
+    )
+    parser.add_argument("--output", "-o", help="Output file path (default: stdout)")
+    parser.add_argument("--validate", action="store_true", help="Validate the attestation structure")
+
+    args = parser.parse_args()
+
+    try:
+        scan_summary = load_json(args.scan_summary_file)
+    except FileNotFoundError:
+        print(f"Error: scan summary not found: {args.scan_summary_file}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(f"Error: invalid JSON in scan summary: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    source_repository: str | None = None
+    try:
+        spec = load_yaml(args.config_file)
+        provenance = spec.get("provenance") or {}
+        source_repository = provenance.get("repository_uri") or (spec.get("spec") or {}).get("repository")
+        if source_repository:
+            print(f"Source repository: {source_repository}", file=sys.stderr)
+    except (FileNotFoundError, yaml.YAMLError) as exc:
+        print(f"Warning: could not read spec.yaml for provenance: {exc}", file=sys.stderr)
+
+    attestation = build_scai_attestation(
+        scan_summary=scan_summary,
+        scan_summary_path=args.scan_summary_file,
+        image_name=args.image_name,
+        image_digest=args.image_digest,
+        config_file=args.config_file,
+        commit_sha=args.commit_sha,
+        run_id=args.run_id,
+        run_url=args.run_url,
+        producer_uri=args.producer_uri,
+        scanner_version=args.scanner_version,
+        scanner_uri=args.scanner_uri,
+        source_repository=source_repository,
+    )
+
+    if args.validate:
+        errors = validate_attestation(attestation)
+        if errors:
+            print("Validation errors:", file=sys.stderr)
+            for err in errors:
+                print(f"  - {err}", file=sys.stderr)
+            sys.exit(1)
+
+    output_json = json.dumps(attestation, indent=2)
+    if args.output:
+        Path(args.output).write_text(output_json)
+        print(f"Attestation written to {args.output}", file=sys.stderr)
+    else:
+        print(output_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill-scan/global_allowed_issues.yaml
+++ b/scripts/skill-scan/global_allowed_issues.yaml
@@ -1,0 +1,13 @@
+# Global allowed issues for skill security scanning (Cisco AITech taxonomy)
+# See: https://github.com/cisco-ai-defense/skill-scanner
+#
+# Common AITech codes (shared with the MCP scanner's taxonomy):
+#   AITech-1.1  - Prompt injection
+#   AITech-8.2  - Data exfiltration/exposure
+#   AITech-9.1  - System manipulation
+#   AITech-12.1 - Tool exploitation/poisoning
+#
+# These issues are allowed for ALL skills in the registry.
+# For skill-specific exceptions, add them to the skill's spec.yaml file instead.
+
+allowed_issues: []

--- a/scripts/skill-scan/process_scan_results.py
+++ b/scripts/skill-scan/process_scan_results.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Process Cisco AI Defense skill-scanner results and emit a summary.
+
+The skill-scanner report is a single JSON document with a flat
+`findings[]` array. Each finding carries `rule_id`, `category`,
+`severity`, plus file/line context. This script applies a two-tier
+allowlist (global + per-skill spec.yaml) and exits non-zero when any
+finding is NOT allowlisted.
+
+Usage:
+    process_scan_results.py <scan_output_file> <skill_name> [spec_file]
+"""
+
+import json
+import os
+import sys
+
+import yaml
+
+
+GLOBAL_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "global_allowed_issues.yaml")
+
+
+def _load_allowed_entries(path: str) -> list[dict]:
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path) as f:
+            config = yaml.safe_load(f) or {}
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: could not load {path}: {exc}", file=sys.stderr)
+        return []
+    entries = config.get("allowed_issues") or []
+    return [e for e in entries if isinstance(e, dict)]
+
+
+def load_security_config(spec_file: str | None) -> tuple[list[dict], bool]:
+    """Merge global and per-skill allowlist entries.
+
+    Per-skill entries are appended after global entries; both are
+    checked on match. Returns (entries, insecure_ignore).
+    """
+    entries: list[dict] = _load_allowed_entries(GLOBAL_CONFIG_FILE)
+    insecure_ignore = False
+
+    if spec_file and os.path.exists(spec_file):
+        try:
+            with open(spec_file) as f:
+                spec = yaml.safe_load(f) or {}
+        except Exception as exc:  # noqa: BLE001
+            print(f"Warning: could not load {spec_file}: {exc}", file=sys.stderr)
+            spec = {}
+
+        security = spec.get("security") or {}
+        insecure_ignore = bool(security.get("insecure_ignore", False))
+        per_skill = security.get("allowed_issues") or []
+        entries.extend([e for e in per_skill if isinstance(e, dict)])
+
+    return entries, insecure_ignore
+
+
+def match_allowlist(finding: dict, entries: list[dict]) -> tuple[bool, str | None]:
+    """Return (allowed, reason). Match by rule_id (exact) or category (broader)."""
+    rule_id = finding.get("rule_id") or ""
+    category = finding.get("category") or ""
+    for entry in entries:
+        if entry.get("rule_id") and entry["rule_id"] == rule_id:
+            return True, entry.get("reason", "Explicitly allowed")
+        if entry.get("category") and entry["category"] == category:
+            return True, entry.get("reason", f"Category '{category}' allowed")
+    return False, None
+
+
+def classify_findings(scan: dict, entries: list[dict]) -> tuple[list[dict], list[dict]]:
+    blocking: list[dict] = []
+    allowed: list[dict] = []
+    for finding in scan.get("findings") or []:
+        if not isinstance(finding, dict):
+            continue
+        detail = {
+            "code": finding.get("rule_id") or finding.get("id") or "unknown",
+            "rule_id": finding.get("rule_id"),
+            "category": finding.get("category"),
+            "severity": finding.get("severity"),
+            "analyzer": finding.get("analyzer"),
+            "title": finding.get("title"),
+            "message": finding.get("description") or finding.get("title") or "",
+            "file_path": finding.get("file_path"),
+            "line_number": finding.get("line_number"),
+        }
+        is_allowed, reason = match_allowlist(finding, entries)
+        if is_allowed:
+            detail["allowed_reason"] = reason
+            allowed.append(detail)
+        else:
+            blocking.append(detail)
+    return blocking, allowed
+
+
+def _warn_summary(skill_name: str, message: str) -> dict:
+    return {
+        "skill": skill_name,
+        "status": "warning",
+        "findings_count": 0,
+        "message": message,
+    }
+
+
+def _error_summary(skill_name: str, message: str) -> dict:
+    return {
+        "skill": skill_name,
+        "status": "error",
+        "message": message,
+    }
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(
+            "Usage: process_scan_results.py <scan_output_file> <skill_name> [spec_file]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    scan_file = sys.argv[1]
+    skill_name = sys.argv[2]
+    spec_file = sys.argv[3] if len(sys.argv) > 3 else None
+
+    entries, insecure_ignore = load_security_config(spec_file)
+
+    try:
+        with open(scan_file) as f:
+            content = f.read()
+    except FileNotFoundError:
+        summary = (
+            _warn_summary(skill_name, f"Scan output not found: {scan_file}")
+            if insecure_ignore
+            else _error_summary(skill_name, f"Scan output not found: {scan_file}")
+        )
+        print(json.dumps(summary, indent=2))
+        sys.exit(0 if insecure_ignore else 1)
+
+    if not content.strip():
+        summary = (
+            _warn_summary(skill_name, "Scan produced empty output")
+            if insecure_ignore
+            else _error_summary(skill_name, "Scan produced empty output")
+        )
+        print(json.dumps(summary, indent=2))
+        sys.exit(0 if insecure_ignore else 1)
+
+    try:
+        scan = json.loads(content)
+    except json.JSONDecodeError as exc:
+        summary = (
+            _warn_summary(skill_name, f"Could not parse scan output: {exc}")
+            if insecure_ignore
+            else _error_summary(skill_name, f"Could not parse scan output: {exc}")
+        )
+        print(json.dumps(summary, indent=2))
+        sys.exit(0 if insecure_ignore else 1)
+
+    blocking, allowed = classify_findings(scan, entries)
+    analyzers = scan.get("analyzers_used") or []
+    findings_count = scan.get("findings_count", len(scan.get("findings") or []))
+
+    if blocking:
+        summary = {
+            "skill": skill_name,
+            "status": "failed",
+            "findings_count": findings_count,
+            "analyzers": analyzers,
+            "blocking_issues": blocking,
+            "blocking_count": len(blocking),
+            "allowed_issues": allowed,
+            "allowed_count": len(allowed),
+        }
+        print(f"Skill security scan FAILED for {skill_name}:", file=sys.stderr)
+        for issue in blocking:
+            if issue.get("file_path"):
+                loc = f" ({issue['file_path']}"
+                if issue.get("line_number"):
+                    loc += f":{issue['line_number']}"
+                loc += ")"
+            else:
+                loc = ""
+            print(
+                f"  - [{issue['code']}] ({issue['severity']}) {issue['message']}{loc}",
+                file=sys.stderr,
+            )
+        if allowed:
+            print(f"Allowlisted (not blocking):", file=sys.stderr)
+            for issue in allowed:
+                print(
+                    f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
+                    file=sys.stderr,
+                )
+        print(json.dumps(summary, indent=2))
+        sys.exit(1)
+
+    summary = {
+        "skill": skill_name,
+        "status": "passed",
+        "findings_count": findings_count,
+        "analyzers": analyzers,
+        "message": "No blocking security issues detected",
+    }
+    if allowed:
+        summary["allowed_issues"] = allowed
+        summary["allowed_count"] = len(allowed)
+        print(f"Skill security scan passed for {skill_name} with allowlisted findings:", file=sys.stderr)
+        for issue in allowed:
+            print(
+                f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
+                file=sys.stderr,
+            )
+    else:
+        print(f"Skill security scan passed for {skill_name} (no findings)", file=sys.stderr)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skill-scan/requirements.txt
+++ b/scripts/skill-scan/requirements.txt
@@ -1,0 +1,5 @@
+# Python dependencies for skill scan scripts
+# Pinned for reproducible builds and supply chain security
+
+cisco-ai-skill-scanner==2.0.9
+pyyaml==6.0.3

--- a/scripts/skill-scan/run_scan.py
+++ b/scripts/skill-scan/run_scan.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Wrapper for Cisco AI Defense skill-scanner.
+
+Runs skill-scanner against a skill source directory and writes the JSON
+report to a file. Allowlist filtering and exit-code logic live in
+process_scan_results.py so the scanner always runs to completion here.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+
+def is_scanner_installed() -> bool:
+    return shutil.which("skill-scanner") is not None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run Cisco AI Defense skill-scanner against a skill source directory"
+    )
+    parser.add_argument(
+        "--source",
+        required=True,
+        help="Path to the skill source directory containing SKILL.md",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write scanner JSON output",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.source):
+        print(f"Error: source directory not found: {args.source}", file=sys.stderr)
+        sys.exit(1)
+
+    scanner_args = [
+        "scan",
+        args.source,
+        "--format", "json",
+        "--output-json", args.output,
+    ]
+
+    if os.environ.get("SKILL_SCANNER_USE_BEHAVIORAL", "").lower() == "true":
+        scanner_args.append("--use-behavioral")
+
+    if os.environ.get("SKILL_SCANNER_USE_LLM", "").lower() == "true":
+        if os.environ.get("SKILL_SCANNER_LLM_API_KEY"):
+            scanner_args.append("--use-llm")
+        else:
+            print(
+                "Warning: SKILL_SCANNER_USE_LLM=true but SKILL_SCANNER_LLM_API_KEY not set",
+                file=sys.stderr,
+            )
+
+    if is_scanner_installed():
+        cmd = ["skill-scanner"] + scanner_args
+    else:
+        cmd = ["uv", "run", "--with", "cisco-ai-skill-scanner", "skill-scanner"] + scanner_args
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False, timeout=600)
+        if result.stdout:
+            print(result.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        if result.returncode != 0:
+            print(
+                f"skill-scanner exited with status {result.returncode}; "
+                "process_scan_results.py will decide whether findings block the build",
+                file=sys.stderr,
+            )
+        sys.exit(0)
+    except subprocess.TimeoutExpired:
+        print("Error running skill-scanner: scan timed out after 600 seconds", file=sys.stderr)
+        sys.exit(1)
+    except FileNotFoundError as e:
+        print(f"Error running skill-scanner: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claude-api/spec.yaml
+++ b/skills/claude-api/spec.yaml
@@ -16,3 +16,10 @@ spec:
 provenance:
   repository_uri: "https://github.com/anthropics/skills"
   repository_ref: "refs/heads/main"
+
+security:
+  # skill-scanner findings that are safe to ignore for this specific skill.
+  # Match by exact rule_id (preferred) or broader category.
+  allowed_issues:
+    - rule_id: SOCIAL_ENG_ANTHROPIC_IMPERSONATION
+      reason: "claude-api is packaged from anthropics/skills — the Anthropic branding is authentic, not impersonation."


### PR DESCRIPTION
## Summary

Adds the skill security pipeline that mirrors the existing MCP pipeline:
every skill whose `spec.yaml` changes is scanned by
[cisco-ai-skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) before its OCI
artifact can be built. Findings are filtered through a two-tier allowlist
(global + per-skill in `spec.yaml`). On success, the scan result is
packaged into an in-toto **SCAI v0.3** predicate attestation (cosign-signed)
alongside the SBOM and SLSA provenance attestations landed in #462.

This is Step 2 of the planned sequence. Step 3 will submit `claude-api`
to `toolhive-catalog` referencing the now fully-attested OCI artifact.

## Key design choices

- **Native taxonomy, not AITech.** Unlike the MCP scanner (AITech codes),
  skill-scanner emits a flat `findings[]` array with `rule_id` + `category`.
  The new `scripts/skill-scan/process_scan_results.py` is a fork of the MCP
  processor adapted to that schema — allowlist match is by exact `rule_id`
  (preferred) or broader `category`.
- **Scan only specs that actually changed.** New `scan-configs` output from
  `discover-skill-configs` matches the MCP pipeline's semantics: when
  `go.mod` / `cmd/dockhand/` / `internal/skills/` / `scripts/skill-scan/`
  changes, _rebuild_ all skills but _scan_ only the specs that truly changed.
- **Gate build on scan.** `build-skill-artifacts` now `needs` the scan job
  with `if: success || skipped`. Matches `build-containers.yml:327`.
- **SCAI shape matches the MCP pipeline** so downstream consumers can
  evaluate skills and servers uniformly. Attribute is
  `SKILL_SECURITY_SCAN_{PASSED,WARNING,FAILED}`, scanner URI is
  `https://github.com/cisco-ai-defense/skill-scanner`.
- **Companion PR-comment workflow.** `skill-scan-report.yml` runs via
  `workflow_run` so it can comment on forked-PR scans. Mirrors
  `mcp-scan-report.yml`.
- **Self-test on workflow changes.** Both `build-skills.yml` and
  `skill-scan-report.yml` are added to the workflow's own trigger paths,
  so CI exercises this pipeline the next time we edit either of them.

## claude-api allowlist

`skills/claude-api/spec.yaml` now allowlists `SOCIAL_ENG_ANTHROPIC_IMPERSONATION`
with the reason that the skill is packaged from `anthropics/skills`
(the upstream Anthropic org) — the Anthropic branding is authentic, not
impersonation. Without this entry the scan job would block publishing.

## Files

**New** — `scripts/skill-scan/` (README, requirements.txt, global_allowed_issues.yaml, run_scan.py, process_scan_results.py, generate_scai_attestation.py).
**New** — `.github/workflows/skill-scan-report.yml`.
**Modified** — `.github/workflows/build-skills.yml` (scan job + gating + SCAI attestation + save-pr-number).
**Modified** — `skills/claude-api/spec.yaml` (allowlist entry).
**Modified** — `Taskfile.yml` (`task scan-skill` and `scan-skill-setup`).

## Tested locally

```
$ task scan-skill -- skills/claude-api
...
Skill security scan passed for claude-api with allowlisted findings:
  - [SOCIAL_ENG_ANTHROPIC_IMPERSONATION] Skill name or description contains 'Anthropic', suggesting official affiliation (Allowed: ...)
{
  "skill": "claude-api",
  "status": "passed",
  "findings_count": 1,
  "analyzers": ["static_analyzer", "bytecode", "pipeline"],
  "allowed_count": 1,
  ...
}
```

SCAI attestation generator produces a valid in-toto statement with
`SKILL_SECURITY_SCAN_PASSED` attribute, `findingsCount: 1`, `blockingIssues: 0`,
`allowedIssues: 1`.

## Test plan

- [ ] PR run: `skill-security-scan` job passes for claude-api (allowlist catches the FP). `build-skill-artifacts` runs in dry-run mode (no push, no attestations on PRs).
- [ ] PR run: companion `Skill Scan Report` workflow upserts a single comment on this PR summarizing the scan.
- [ ] After merge to `main`: `cosign tree ghcr.io/stacklok/dockyard/skills/claude-api:0.1.0` shows signature + SBOM attestation + SLSA provenance attestation + SCAI attestation.
- [ ] After merge: `cosign verify-attestation --type https://in-toto.io/attestation/scai/v0.3 --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp 'https://github.com/stacklok/dockyard/.github/workflows/build-skills.yml.*' ghcr.io/stacklok/dockyard/skills/claude-api@<digest>` resolves and includes `scanner: cisco-ai-skill-scanner`.
- [ ] Removing the allowlist entry from `spec.yaml` causes the scan job to fail on the next PR and block `build-skill-artifacts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)