### PR TITLE
feat(skills): package 16 Trail of Bits skills

### DIFF
--- a/skills/agentic-actions-auditor/spec.yaml
+++ b/skills/agentic-actions-auditor/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits agentic-actions-auditor Skill
+# Audits GitHub Actions workflows for AI agent security vulnerabilities.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/agentic-actions-auditor:0.1.0
+
+metadata:
+  name: agentic-actions-auditor
+  description: "Audit GitHub Actions workflows for security vulnerabilities in AI agent integrations (Claude Code Action, Gemini CLI, Codex) — detects prompt injection, env-var intermediary patterns, and wildcard user allowlists"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/agentic-actions-auditor/skills/agentic-actions-auditor"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/codeql/spec.yaml
+++ b/skills/codeql/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits codeql Skill
+# Scans a codebase for security vulnerabilities using CodeQL.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/codeql:0.1.0
+
+metadata:
+  name: codeql
+  description: "Scan a codebase for security vulnerabilities using CodeQL's interprocedural data flow and taint tracking — supports security-and-quality suites or high-precision findings, plus SARIF output handling"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/static-analysis/skills/codeql"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/constant-time-analysis/spec.yaml
+++ b/skills/constant-time-analysis/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits constant-time-analysis Skill
+# Detects compiler-induced timing side-channels in cryptographic code.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/constant-time-analysis:0.1.0
+
+metadata:
+  name: constant-time-analysis
+  description: "Detect timing side-channels in cryptographic code — covers C, C++, Go, Rust, Swift, Java, Kotlin, C#, PHP, JS/TS, Python, and Ruby; flags division on secrets and secret-dependent branches"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/constant-time-analysis/skills/constant-time-analysis"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/differential-review/spec.yaml
+++ b/skills/differential-review/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits differential-review Skill
+# Security-focused differential review of code changes.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/differential-review:0.1.0
+
+metadata:
+  name: differential-review
+  description: "Security-focused differential review of PRs, commits, and diffs — uses git history for context, calculates blast radius, checks test coverage, and flags security regressions"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/differential-review/skills/differential-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/fp-check/spec.yaml
+++ b/skills/fp-check/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits fp-check Skill
+# Systematically verifies suspected security bugs to eliminate false positives.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/fp-check:0.1.0
+
+metadata:
+  name: fp-check
+  description: "Systematically verify suspected security bugs to eliminate false positives — produces TRUE POSITIVE or FALSE POSITIVE verdicts with documented evidence per bug, with mandatory gate reviews"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/fp-check/skills/fp-check"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/insecure-defaults/spec.yaml
+++ b/skills/insecure-defaults/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits insecure-defaults Skill
+# Detects fail-open insecure defaults.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/insecure-defaults:0.1.0
+
+metadata:
+  name: insecure-defaults
+  description: "Detect fail-open insecure defaults — hardcoded secrets, weak auth, permissive security settings, and misconfigured environment variable handling that let apps run insecurely in production"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/insecure-defaults/skills/insecure-defaults"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/property-based-testing/spec.yaml
+++ b/skills/property-based-testing/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits property-based-testing Skill
+# Guidance for property-based testing across languages and smart contracts.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/property-based-testing:0.1.0
+
+metadata:
+  name: property-based-testing
+  description: "Property-based testing guidance across multiple languages and smart contracts — use when writing tests, designing features with serialization/validation/parsing, or when stronger coverage than example-based tests is needed"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/property-based-testing/skills/property-based-testing"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/sarif-parsing/spec.yaml
+++ b/skills/sarif-parsing/spec.yaml
@@ -1,0 +1,25 @@
+# Trail of Bits sarif-parsing Skill
+# Parses and processes SARIF files from static analysis tools.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/sarif-parsing:0.1.0
+
+metadata:
+  name: sarif-parsing
+  description: "Parse, filter, deduplicate, and convert SARIF files from CodeQL, Semgrep, and other scanners — for CI/CD integration and findings aggregation (does not run scans — pair with the codeql or semgrep skills for that)"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/static-analysis/skills/sarif-parsing"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."
+    - rule_id: ALLOWED_TOOLS_WRITE_VIOLATION
+      reason: "SKILL.md declares Bash in allowed-tools, which transitively permits filesystem writes (e.g. via redirection); the scanner flags bundled scripts as writing without recognizing Bash as the intended mechanism."

--- a/skills/semgrep-rule-creator/spec.yaml
+++ b/skills/semgrep-rule-creator/spec.yaml
@@ -1,0 +1,25 @@
+# Trail of Bits semgrep-rule-creator Skill
+# Creates custom Semgrep rules for detecting security vulnerabilities.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/semgrep-rule-creator:0.1.0
+
+metadata:
+  name: semgrep-rule-creator
+  description: "Create custom Semgrep rules for detecting security vulnerabilities, bug patterns, and code patterns — use when writing Semgrep rules or building tailored static analysis detections"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/semgrep-rule-creator/skills/semgrep-rule-creator"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."
+    - rule_id: YARA_code_execution_generic
+      reason: "Matches eval() example snippets in SKILL.md that illustrate vulnerability patterns a custom Semgrep rule should detect; these are documentation of target code, not executable paths within the skill."

--- a/skills/semgrep-rule-variant-creator/spec.yaml
+++ b/skills/semgrep-rule-variant-creator/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits semgrep-rule-variant-creator Skill
+# Ports existing Semgrep rules to new target languages.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/semgrep-rule-variant-creator:0.1.0
+
+metadata:
+  name: semgrep-rule-variant-creator
+  description: "Port existing Semgrep rules to new target languages with test-driven validation — produces independent rule and test directories for each target language"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/semgrep/spec.yaml
+++ b/skills/semgrep/spec.yaml
@@ -1,0 +1,25 @@
+# Trail of Bits semgrep Skill
+# Runs Semgrep static analysis with parallel subagents.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/semgrep:0.1.0
+
+metadata:
+  name: semgrep
+  description: "Run Semgrep static analysis with parallel subagents — full ruleset or high-confidence security findings only; auto-detects Semgrep Pro for cross-file taint analysis across multi-language codebases"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/static-analysis/skills/semgrep"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."
+    - rule_id: ALLOWED_TOOLS_GREP_VIOLATION
+      reason: "SKILL.md declares Bash in allowed-tools, which transitively covers regex search via shell tooling; the scanner does not account for this capability."

--- a/skills/sharp-edges/spec.yaml
+++ b/skills/sharp-edges/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits sharp-edges Skill
+# Identifies error-prone APIs, dangerous configurations, and footgun designs.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/sharp-edges:0.1.0
+
+metadata:
+  name: sharp-edges
+  description: "Identify error-prone APIs, dangerous configurations, and footgun designs — evaluates whether code follows 'secure by default' and 'pit of success' principles for API usability and crypto library ergonomics"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/sharp-edges/skills/sharp-edges"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/supply-chain-risk-auditor/spec.yaml
+++ b/skills/supply-chain-risk-auditor/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits supply-chain-risk-auditor Skill
+# Identifies dependencies at heightened risk of exploitation or takeover.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/supply-chain-risk-auditor:0.1.0
+
+metadata:
+  name: supply-chain-risk-auditor
+  description: "Audit a project's dependencies for supply-chain attack surface — flags libraries at heightened risk of exploitation or takeover based on health, maintainership, and activity signals"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/variant-analysis/spec.yaml
+++ b/skills/variant-analysis/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits variant-analysis Skill
+# Finds similar vulnerabilities across codebases after an initial finding.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/variant-analysis:0.1.0
+
+metadata:
+  name: variant-analysis
+  description: "Find similar vulnerabilities and bugs across a codebase after an initial finding — pattern-based analysis for hunting variants, building CodeQL/Semgrep queries, and systematic code audits"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/variant-analysis/skills/variant-analysis"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/yara-rule-authoring/spec.yaml
+++ b/skills/yara-rule-authoring/spec.yaml
@@ -1,0 +1,23 @@
+# Trail of Bits yara-rule-authoring Skill
+# Guides authoring of high-quality YARA-X detection rules.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/yara-rule-authoring:0.1.0
+
+metadata:
+  name: yara-rule-authoring
+  description: "Author high-quality YARA-X detection rules for malware identification — covers naming conventions, string selection, performance optimization, migration from legacy YARA, and false-positive reduction"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/yara-authoring/skills/yara-rule-authoring"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."

--- a/skills/zeroize-audit/spec.yaml
+++ b/skills/zeroize-audit/spec.yaml
@@ -1,0 +1,29 @@
+# Trail of Bits zeroize-audit Skill
+# Detects missing or compiler-eliminated zeroization of secrets.
+# Source: https://github.com/trailofbits/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/zeroize-audit:0.1.0
+
+metadata:
+  name: zeroize-audit
+  description: "Detect missing or compiler-eliminated zeroization of secrets in C/C++ and Rust — assembly-level analysis and control-flow verification for code handling keys, passwords, or sensitive data"
+
+spec:
+  repository: "https://github.com/trailofbits/skills"
+  ref: "e8cc5baf9329ccb491bfa200e82eacbac83b1ead"  # main as of 2026-04-17
+  path: "plugins/zeroize-audit/skills/zeroize-audit"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/trailofbits/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "trailofbits/skills is licensed CC-BY-SA-4.0 at the repository root; upstream does not embed a license field in per-skill SKILL.md frontmatter."
+    - rule_id: PATH_TRAVERSAL_OPEN
+      reason: "tools/generate_poc.py writes generated PoC sources to an operator-supplied output directory with filenames derived from internal finding metadata; no externally controlled path input."
+    - rule_id: YARA_coercive_injection_generic
+      reason: "Matches the phrase 'secret argument' in tools/scripts/check_llvm_patterns.py where it labels compiler-detected patterns; the skill audits zeroization of secrets so references to the word 'secret' are expected."
+    - rule_id: DATA_EXFIL_SENSITIVE_FILES
+      reason: "tools/scripts/check_rust_asm.py reads a JSON config of Rust symbol names to audit; 'secrets_path' is the skill's internal config file path, not exfiltration of user secrets."


### PR DESCRIPTION
## Summary

Packages 16 security-focused agent skills from [`trailofbits/skills`](https://github.com/trailofbits/skills) (CC-BY-SA-4.0) into Dockyard. All skills pinned to upstream commit [`e8cc5ba`](https://github.com/trailofbits/skills/commit/e8cc5baf9329ccb491bfa200e82eacbac83b1ead) (main as of 2026-04-17).

This is the first of a planned vendor-by-vendor sweep of publicly-available hardened agent skills. A parallel survey of Chainguard's recently-announced Agent Skills catalog turned up no open-source content — their catalog is beta-gated behind contact sales — so there's nothing to repackage from them.

### Skills added

**Security analysis**
- `agentic-actions-auditor` — audits GitHub Actions workflows for AI-agent security holes (prompt injection, env-var intermediary, wildcard allowlists)
- `codeql`, `semgrep`, `sarif-parsing` — classic SAST tooling from the `static-analysis` plugin
- `semgrep-rule-creator`, `semgrep-rule-variant-creator` — authoring and porting custom Semgrep rules

**Supply chain and defensive review**
- `supply-chain-risk-auditor` — dependency takeover/exploitation risk
- `insecure-defaults` — fail-open configurations and hardcoded secrets
- `sharp-edges` — footgun APIs and dangerous defaults
- `fp-check` — false-positive verification with gate reviews
- `differential-review` — security-focused PR/commit review
- `variant-analysis` — finding bug variants across a codebase

**Cryptographic verification**
- `constant-time-analysis` — timing side-channels across 12 languages
- `zeroize-audit` — compiler-eliminated zeroization in C/C++/Rust
- `property-based-testing` — PBT guidance across multiple languages

**Malware analysis**
- `yara-rule-authoring` — YARA-X detection rule authoring

### Skills intentionally excluded

TOB internal / narrow-audience plugins (`debug-buttercup`, `culture-index`, `claude-in-chrome-troubleshooting`, `let-fate-decide`, `skill-improver`, `workflow-skill-design`, etc.), fuzzing toolkits from `testing-handbook-skills` (15 skills — candidates for a follow-up PR if there's interest), blockchain-specific scanners from `building-secure-contracts` (11 skills — same), and `trailmark` (10 skills, TOB-specific workflow).

### Security allowlists

All 16 carry one allowlist entry for `MANIFEST_MISSING_LICENSE` (INFO) — upstream licenses at the repo root under CC-BY-SA-4.0 rather than in per-skill SKILL.md frontmatter. Four skills carry additional per-skill entries for scanner false positives documented inline:
- `sarif-parsing` / `semgrep` — `ALLOWED_TOOLS_*_VIOLATION` (scanner doesn't account for `Bash` covering grep/write transitively)
- `semgrep-rule-creator` — `YARA_code_execution_generic` matching documented `eval()` examples the skill teaches you to detect
- `zeroize-audit` — `PATH_TRAVERSAL_OPEN`, `YARA_coercive_injection_generic`, `DATA_EXFIL_SENSITIVE_FILES` matching the word "secret" in a skill that audits zeroization of secrets

## Test plan

- [x] `task validate-skill -- skills/<name>` against all 16 (all VALID)
- [x] Cisco AI Defense skill-scanner 2.0.9 against all 16 sources — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds on this PR
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 16 OCI artifacts published under `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)