### PR TITLE
feat(skills): package 18 Sentry skills

### DIFF
--- a/skills/agents-md/spec.yaml
+++ b/skills/agents-md/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry agents-md Skill
+# Maintain concise AGENTS.md / CLAUDE.md agent-facing documentation.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/agents-md:0.1.0
+
+metadata:
+  name: agents-md
+  description: "Create and maintain minimal, high-signal AGENTS.md / CLAUDE.md agent docs — under 60 lines target, detects package manager and file-scoped commands, avoids filler and duplicated linter rules"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/agents-md"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/claude-settings-audit/spec.yaml
+++ b/skills/claude-settings-audit/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry claude-settings-audit Skill
+# Generate recommended Claude Code settings.json permissions from detected stack.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/claude-settings-audit:0.1.0
+
+metadata:
+  name: claude-settings-audit
+  description: "Analyze a repository and generate recommended Claude Code settings.json permissions for read-only commands — detects tech stack, package managers, build tools, monorepo structure, and framework-specific doc domains"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/claude-settings-audit"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/code-review/spec.yaml
+++ b/skills/code-review/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry code-review Skill
+# Code review following Sentry engineering practices.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/code-review:0.1.0
+
+metadata:
+  name: code-review
+  description: "Perform code reviews following Sentry engineering practices — runtime errors, performance, side effects, backwards compatibility, ORM queries, security, test coverage, and long-term impact assessment"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/code-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/code-simplifier/spec.yaml
+++ b/skills/code-simplifier/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry code-simplifier Skill
+# Simplify and refine code for clarity while preserving functionality.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/code-simplifier:0.1.0
+
+metadata:
+  name: code-simplifier
+  description: "Simplify and refine code for clarity, consistency, and maintainability while preserving functionality — prefers explicit over clever, flattens nested ternaries, removes redundant abstractions, follows project conventions"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/code-simplifier"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/commit/spec.yaml
+++ b/skills/commit/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry commit Skill
+# Create commits following Sentry conventional-commit conventions.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/commit:0.1.0
+
+metadata:
+  name: commit
+  description: "Create commits following Sentry conventional-commit format — type(scope): subject, imperative body, proper issue references (Fixes/Refs GH-NNNN, SENTRY-NNNN, LINEAR-XXX)"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/commit"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/create-branch/spec.yaml
+++ b/skills/create-branch/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry create-branch Skill
+# Create a git branch following Sentry naming conventions.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/create-branch:0.1.0
+
+metadata:
+  name: create-branch
+  description: "Create a git branch following Sentry naming conventions — <prefix>/<type>/<short-description> with automatic prefix resolution from GitHub user, diff-derived description, and default-branch detection"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/create-branch"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/django-access-review/spec.yaml
+++ b/skills/django-access-review/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry django-access-review Skill
+# Django access control and IDOR security review.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/django-access-review:0.1.0
+
+metadata:
+  name: django-access-review
+  description: "Django access-control and IDOR review — investigates how authorization is enforced (decorators, managers, permission classes, mixins) and finds gaps where User A can access User B's data"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/django-access-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/django-perf-review/spec.yaml
+++ b/skills/django-perf-review/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry django-perf-review Skill
+# Django performance review with validation-first reporting.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/django-perf-review:0.1.0
+
+metadata:
+  name: django-perf-review
+  description: "Django performance review — validates N+1 queries, unbounded querysets, missing indexes, and write loops before reporting; severity must match measurable impact"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/django-perf-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/doc-coauthoring/spec.yaml
+++ b/skills/doc-coauthoring/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry doc-coauthoring Skill
+# Structured co-authoring workflow for documentation.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/doc-coauthoring:0.1.0
+
+metadata:
+  name: doc-coauthoring
+  description: "Guide users through a three-stage doc co-authoring workflow — context gathering, section-by-section refinement and structure, and reader testing with a fresh agent to catch blind spots"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/doc-coauthoring"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/find-bugs/spec.yaml
+++ b/skills/find-bugs/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry find-bugs Skill
+# Bug, vulnerability, and code-quality review across local branch changes.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/find-bugs:0.1.0
+
+metadata:
+  name: find-bugs
+  description: "Find bugs, security vulnerabilities, and quality issues on the current branch — diff-scoped review with security checklist covering injection, XSS, auth, IDOR, race conditions, and business-logic edge cases"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/find-bugs"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/gh-review-requests/spec.yaml
+++ b/skills/gh-review-requests/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry gh-review-requests Skill
+# Fetch unread GitHub review-request notifications filtered by team.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/gh-review-requests:0.1.0
+
+metadata:
+  name: gh-review-requests
+  description: "Fetch unread review_requested GitHub notifications filtered by team — lists open PRs where a specified team is a requested reviewer or a team member is the author"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/gh-review-requests"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/gha-security-review/spec.yaml
+++ b/skills/gha-security-review/spec.yaml
@@ -1,0 +1,25 @@
+# Sentry gha-security-review Skill
+# GitHub Actions security review for pwn-request, expression injection, credential theft.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/gha-security-review:0.1.0
+
+metadata:
+  name: gha-security-review
+  description: "GitHub Actions workflow security review with concrete exploitation scenarios — pwn-request, expression injection, credential escalation, config poisoning, and supply-chain audits"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/gha-security-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's reference material cites `curl | bash` and similar RCE patterns as instructional examples of supply-chain-style attacks detectable in CI workflows. The scanner itself flags these as 'found in documentation file — may be instructional rather than executable'."

--- a/skills/iterate-pr/spec.yaml
+++ b/skills/iterate-pr/spec.yaml
@@ -1,0 +1,25 @@
+# Sentry iterate-pr Skill
+# Iterate on a PR until CI passes and review feedback is addressed.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/iterate-pr:0.1.0
+
+metadata:
+  name: iterate-pr
+  description: "Iterate on a PR until CI passes and review feedback is addressed — fetches categorized LOGAF-ranked feedback, auto-fixes high/medium, monitors CI with retry-safe check polling, handles review-bot findings"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/iterate-pr"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: RESOURCE_ABUSE_INFINITE_LOOP
+      reason: "The `scripts/monitor_pr_checks.py` helper polls PR check status in a `while True:` loop with bounded retries and sleep — legitimate for waiting until CI reaches a terminal state. The script has a timeout and exit conditions."

--- a/skills/pr-writer/spec.yaml
+++ b/skills/pr-writer/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry pr-writer Skill
+# Create and update pull requests following Sentry conventions.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pr-writer:0.1.0
+
+metadata:
+  name: pr-writer
+  description: "Create pull requests following Sentry engineering practices — conventional-commit-style titles, why-focused descriptions, issue references (Fixes/Refs), and safe gh-api edits for existing PRs"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/pr-writer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/prompt-optimizer/spec.yaml
+++ b/skills/prompt-optimizer/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry prompt-optimizer Skill
+# Create, optimize, and iteratively refine agent prompts via eval-driven loops.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/prompt-optimizer:0.1.0
+
+metadata:
+  name: prompt-optimizer
+  description: "Create, optimize, and iteratively refine agent prompts via eval-driven workflow — model-family-specific guidance (Claude, OpenAI, Gemini), prompt markers, meta-optimization loop, and cross-family adapter notes"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/prompt-optimizer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/security-review/spec.yaml
+++ b/skills/security-review/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry security-review Skill
+# OWASP-style vulnerability review with confidence-based reporting.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/security-review:0.1.0
+
+metadata:
+  name: security-review
+  description: "Security code review for vulnerabilities — systematic, confidence-scored reporting of injection, XSS, auth, crypto, and deserialization issues with framework-aware false-positive filtering"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/security-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/skill-scanner/spec.yaml
+++ b/skills/skill-scanner/spec.yaml
@@ -1,0 +1,29 @@
+# Sentry skill-scanner Skill
+# Scans agent skills for prompt injection, malicious code, excessive permissions.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/skill-scanner:0.1.0
+
+metadata:
+  name: skill-scanner
+  description: "Scan agent skills for security issues — prompt injection, malicious scripts, excessive permissions, secret exposure, supply-chain risks; combines static pattern scanner with agent behavioral analysis"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/skill-scanner"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: OBFUSCATION_BASE64_LARGE
+      reason: "This is a meta-skill that teaches detection of malicious patterns. Its reference material cites `exec(base64.b64decode(...))` as an example of obfuscated code the scanner should flag in other skills — the skill documents the pattern it hunts, it does not execute it."
+    - rule_id: PROMPT_INJECTION_UNRESTRICTED_MODE
+      reason: "The skill's reference material on prompt-injection patterns cites 'Enter developer mode' as an example jailbreak pattern the skill teaches to detect. Documenting the pattern is the skill's purpose."
+    - rule_id: YARA_prompt_injection_unicode_steganography
+      reason: "The skill documents invisible Unicode steganography (`\\U000e0001` tag characters) as a prompt-injection vector. Describing the attack class is required for the skill to teach detection of it."

--- a/skills/skill-writer/spec.yaml
+++ b/skills/skill-writer/spec.yaml
@@ -1,0 +1,23 @@
+# Sentry skill-writer Skill
+# Create, synthesize, and iteratively improve agent skills.
+# Source: https://github.com/getsentry/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/skill-writer:0.1.0
+
+metadata:
+  name: skill-writer
+  description: "Create, synthesize, and iteratively improve agent skills per the Agent Skills specification — handles source capture with depth gates, authoring, description optimization, registration, and validation"
+
+spec:
+  repository: "https://github.com/getsentry/skills"
+  ref: "94ea2a26c70f3f646f07a613ffe5cd3d4eca1955"  # main as of 2026-04-20
+  path: "skills/skill-writer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/getsentry/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "getsentry/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Packages 18 agent skills from [`getsentry/skills`](https://github.com/getsentry/skills) (Apache-2.0) into Dockyard. All skills pinned to upstream commit [`94ea2a2`](https://github.com/getsentry/skills/commit/94ea2a26c70f3f646f07a613ffe5cd3d4eca1955) (main as of 2026-04-20).

Second vendor in the per-vendor skills sweep following #466 (Trail of Bits). Sentry is an Anthropic skills launch partner and maintains a security-oriented dev skills pack with strong overlap with Dockyard's existing security catalog.

Tracks #478.

### Skills added

**Security / review** (strong fit)
- `security-review` — OWASP-style vulnerability review with confidence scoring, framework-aware FP filtering
- `gha-security-review` — GitHub Actions pwn-request, expression-injection, config-poisoning audits
- `skill-scanner` — scans other skills for prompt injection, malicious code, excessive permissions
- `find-bugs` — diff-scoped bug/security/quality review with security checklist
- `code-review` — Sentry engineering-practice code review
- `claude-settings-audit` — settings.json permission generator from detected stack/build tools
- `django-access-review` — Django access-control and IDOR investigation
- `django-perf-review` — validated Django performance review (N+1, unbounded querysets, missing indexes)

**Skill authoring and workflow**
- `skill-writer` — create/improve agent skills per the Agent Skills specification
- `prompt-optimizer` — eval-driven prompt optimization with model-family adapters
- `agents-md` — minimal AGENTS.md / CLAUDE.md maintenance
- `doc-coauthoring` — three-stage doc co-authoring workflow (context, refinement, reader-testing)
- `code-simplifier` — clarity-first refactoring without behavior change

**Git and PR workflow**
- `commit` — Sentry conventional-commit format with issue references
- `create-branch` — Sentry naming-convention branch creation
- `pr-writer` — Sentry-style PR titles and why-focused descriptions
- `iterate-pr` — CI-passing loop with LOGAF-ranked feedback handling
- `gh-review-requests` — team-filtered review-request notifications

### Skills intentionally excluded

Sentry-internal or narrow-audience: `brand-guidelines`, `blog-writing-guide`, `sred-project-organizer`, `sred-work-summary`, `typing-exclusion-worker`, `presentation-creator`.

### Security allowlists

All 18 skills carry one allowlist entry for `MANIFEST_MISSING_LICENSE` (INFO) — upstream is licensed Apache-2.0 at the repo root rather than via SPDX identifier in SKILL.md frontmatter.

Three security-oriented skills carry additional per-skill entries for scanner false positives where the skill teaches attack patterns it is designed to detect:

- `gha-security-review` — `PIPELINE_TAINT_FLOW` (`curl | bash` examples in reference docs; the scanner itself notes them as "instructional rather than executable")
- `iterate-pr` — `RESOURCE_ABUSE_INFINITE_LOOP` (bounded-retry poll loop in `scripts/monitor_pr_checks.py` with timeout and exit conditions)
- `skill-scanner` — `OBFUSCATION_BASE64_LARGE`, `PROMPT_INJECTION_UNRESTRICTED_MODE`, `YARA_prompt_injection_unicode_steganography` (the skill documents each detection pattern it teaches other scanners to catch)

## Test plan

- [x] `task validate-skill` against all 18 specs — all VALID
- [x] Cisco AI Defense skill-scanner 2.0.9 against all 18 sources — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds on this PR
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 18 OCI artifacts published under `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`

Closes #478