### PR TITLE
feat(skills): package 8 Socket supply-chain skills

### DIFF
--- a/skills/socket-dep-cleanup/spec.yaml
+++ b/skills/socket-dep-cleanup/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-dep-cleanup Skill
+# Evaluate and remove a single unused dependency from the project.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-dep-cleanup:0.1.0
+
+metadata:
+  name: socket-dep-cleanup
+  description: "Evaluate and remove a single unused dependency — searches the entire codebase for direct imports, indirect references (types packages, plugins, CLI scripts, peer deps, bundler plugins), reports findings, removes with build/test verification"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-fix/socket-dep-cleanup"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-dep-patch/spec.yaml
+++ b/skills/socket-dep-patch/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-dep-patch Skill
+# Apply Socket's binary-level security patches without changing dependency versions.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-dep-patch:0.1.0
+
+metadata:
+  name: socket-dep-patch
+  description: "Apply Socket's binary-level security patches with socket-patch apply — fixes vulnerabilities in-place without version changes, then verifies automated patching is configured so patches persist across installs"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-fix/socket-dep-patch"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-dep-replace/spec.yaml
+++ b/skills/socket-dep-replace/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-dep-replace Skill
+# Replace a dependency with an alternative, inline it, or use socket-optimize.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-dep-replace:0.1.0
+
+metadata:
+  name: socket-dep-replace
+  description: "Replace a dependency — swap with an alternative, eliminate via code rewrite, or use socket-optimize for optimized replacements; builds a full API usage map and executes migration with build/test verification"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-fix/socket-dep-replace"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-dep-upgrade/spec.yaml
+++ b/skills/socket-dep-upgrade/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-dep-upgrade Skill
+# Use socket fix to update vulnerable dependencies and fix breaking changes.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-dep-upgrade:0.1.0
+
+metadata:
+  name: socket-dep-upgrade
+  description: "Upgrade vulnerable dependencies with socket fix — discovers fixable CVEs via Coana analysis, applies one fix at a time via subagents (conservative no-major-updates first, escalate if needed), fixes breaking changes, bails on failure"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-fix/socket-dep-upgrade"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-fix/spec.yaml
+++ b/skills/socket-fix/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-fix Skill
+# Orchestrator that fixes dependency security issues via cleanup, patch, replace, upgrade.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-fix:0.1.0
+
+metadata:
+  name: socket-fix
+  description: "Orchestrate dependency security fixes — Fix All (full scan, tiered aggressiveness: conservative/cautious/full) or Fix Package (single named package); delegates to socket-dep-cleanup, socket-dep-patch, socket-dep-replace, socket-dep-upgrade"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-fix"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-inspect/spec.yaml
+++ b/skills/socket-inspect/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-inspect Skill
+# Research a package before adopting — Socket scores, alerts, CVEs, alternatives.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-inspect:0.1.0
+
+metadata:
+  name: socket-inspect
+  description: "Research a package before depending on it — pulls Socket scores, alerts, malware verdicts, CVEs, dependency tree, maintainer trust; evaluates alternatives and surfaces Socket patches"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-inspect"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-scan/spec.yaml
+++ b/skills/socket-scan/spec.yaml
@@ -1,0 +1,23 @@
+# Socket socket-scan Skill
+# Run a Socket CLI dependency scan with license/compliance audit and reachability.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-scan:0.1.0
+
+metadata:
+  name: socket-scan
+  description: "Run a Socket CLI dependency scan — SBOM generation, vulnerability and malware detection, license auditing, and (for enterprise accounts) reachability analysis; cdxgen fallback for unauthenticated users"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-scan"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/socket-setup/spec.yaml
+++ b/skills/socket-setup/spec.yaml
@@ -1,0 +1,25 @@
+# Socket socket-setup Skill
+# Set up the Socket CLI, authenticate, configure policies and CI integration.
+# Source: https://github.com/SocketDev/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/socket-setup:0.1.0
+
+metadata:
+  name: socket-setup
+  description: "Set up Socket end-to-end — prompts for account tier, installs CLI/sfw/socket-patch, authenticates, configures firewall and patch modes across GitHub, GitLab, Bitbucket, and Dockerfiles"
+
+spec:
+  repository: "https://github.com/SocketDev/skills"
+  ref: "25879b0c8d69cffff9ed895cfb57c12b669f76b2"  # main as of 2026-04-02
+  path: "skills/socket-setup"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/SocketDev/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "SocketDev/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official nvm installer command `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/.../install.sh | bash` as documentation. The scanner itself flags it as 'uses a well-known installer URL — likely a standard installation'."


### PR DESCRIPTION
## Summary

Packages 8 supply-chain security skills from [`SocketDev/skills`](https://github.com/SocketDev/skills) (MIT) into Dockyard. All skills pinned to upstream commit [`25879b0`](https://github.com/SocketDev/skills/commit/25879b0c8d69cffff9ed895cfb57c12b669f76b2) (main as of 2026-04-02).

Third vendor in the per-vendor skills sweep after #466 (Trail of Bits) and #498 (Sentry). Socket.dev is a first-party supply-chain security vendor; this pack complements Dockyard's existing `supply-chain-risk-auditor`.

Tracks #476.

### Skills added

**Scanning and inspection**
- `socket-scan` — dependency scan with SBOM, vulnerabilities, malware, license audit; cdxgen fallback for unauthenticated users
- `socket-inspect` — research a package before adoption — Socket scores, alerts, CVEs, dependency tree, alternatives

**Setup**
- `socket-setup` — install and authenticate the Socket CLI, sfw, socket-patch; configure CI (GitHub/GitLab/Bitbucket) and Dockerfile integration

**Dependency fixing** (umbrella + 4 sub-skills)
- `socket-fix` — orchestrator (Fix All tiered Conservative/Cautious/Full, or Fix Package)
- `socket-dep-cleanup` — evaluate and remove a single unused dependency
- `socket-dep-patch` — apply Socket binary-level patches without version changes
- `socket-dep-replace` — swap a dependency for an alternative, inline, or `socket-optimize`
- `socket-dep-upgrade` — `socket fix` with one-at-a-time version bumps and code migration

### Shared-file note

The `socket-fix` sub-skills reference `skills/_shared/verify-build.md` in the upstream repo. The dockyard OCI packager only bundles files under `spec.path`, so that shared reference file does not ship with the per-skill artifact. The skills remain functional from their own SKILL.md; the shared file is supplementary guidance. If this turns out to be a common pattern across future vendors, we may want to package `_shared` dirs as additional bundled resources or a dedicated skill.

### Security allowlists

All 8 skills carry `MANIFEST_MISSING_LICENSE` (INFO) — upstream is MIT at the repo root rather than as an SPDX identifier in per-skill SKILL.md frontmatter.

`socket-setup` additionally allowlists `PIPELINE_TAINT_FLOW` (LOW): the skill's prerequisites cite the official nvm installer (`curl -o- .../install.sh | bash`) as a documentation example. The scanner itself flags the finding as "uses a well-known installer URL — likely a standard installation."

## Test plan

- [x] `task validate-skill` on all 8 specs — all VALID
- [x] Cisco AI Defense skill-scanner 2.0.9 against all 8 sources — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds on this PR
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 8 OCI artifacts published under `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`

Closes #476