### PR TITLE
feat(skills): package 8 Cloudflare skills

### DIFF
--- a/skills/agents-sdk/spec.yaml
+++ b/skills/agents-sdk/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare agents-sdk Skill
+# Build AI agents on Cloudflare Workers using the Agents SDK.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/agents-sdk:0.1.0
+
+metadata:
+  name: agents-sdk
+  description: "Build AI agents on Cloudflare Workers with the Agents SDK — Agent class, persistent state, callable RPC, Workflows, durable execution, queues, retries, MCP client/server, chat agents, WebSockets, scheduling, observability, and React client hooks"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/agents-sdk"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/cloudflare-email-service/spec.yaml
+++ b/skills/cloudflare-email-service/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare cloudflare-email-service Skill
+# Send and receive transactional emails with Cloudflare Email Service.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/cloudflare-email-service:0.1.0
+
+metadata:
+  name: cloudflare-email-service
+  description: "Send and receive transactional email with Cloudflare Email Service (Email Sending + Email Routing) — Workers bindings, REST API, Agents SDK onEmail/replyToEmail, SPF/DKIM/DMARC, wrangler setup, deliverability"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/cloudflare-email-service"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/cloudflare/spec.yaml
+++ b/skills/cloudflare/spec.yaml
@@ -1,0 +1,25 @@
+# Cloudflare umbrella Skill
+# Comprehensive Cloudflare platform skill with product decision trees.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/cloudflare:0.1.0
+
+metadata:
+  name: cloudflare
+  description: "Comprehensive Cloudflare platform skill — Workers, Pages, storage (KV/D1/R2/Artifacts/Queues), AI (Workers AI, Vectorize, Agents SDK, AI Gateway), networking (Tunnel, Spectrum), security (WAF, DDoS, Turnstile), and IaC (Terraform, Pulumi); decision trees for product selection"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/cloudflare"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: EXCESSIVE_FILE_COUNT
+      reason: "This umbrella skill ships one `references/<product>/` subdirectory per Cloudflare product (316 files total). The large file count is by upstream design — the skill functions as a product index that routes to the relevant reference for any Cloudflare task. All files are Cloudflare-authored documentation, not bundled dependencies."

--- a/skills/durable-objects/spec.yaml
+++ b/skills/durable-objects/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare durable-objects Skill
+# Create and review Cloudflare Durable Objects.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/durable-objects:0.1.0
+
+metadata:
+  name: durable-objects
+  description: "Create and review Cloudflare Durable Objects — stateful coordination (chat rooms, multiplayer, booking), RPC methods, SQLite storage, alarms, WebSockets, wrangler config, Vitest testing"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/durable-objects"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/sandbox-sdk/spec.yaml
+++ b/skills/sandbox-sdk/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare sandbox-sdk Skill
+# Build sandboxed applications for secure code execution.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/sandbox-sdk:0.1.0
+
+metadata:
+  name: sandbox-sdk
+  description: "Build sandboxed apps for secure code execution — AI code interpreters, CI sandboxes, interactive dev environments; Sandbox SDK lifecycle, exec/runCode, file ops, preview URLs, OpenAI Agents SDK integration"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/sandbox-sdk"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/web-perf/spec.yaml
+++ b/skills/web-perf/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare web-perf Skill
+# Web performance audit via Chrome DevTools MCP.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/web-perf:0.1.0
+
+metadata:
+  name: web-perf
+  description: "Web performance audit via Chrome DevTools MCP — measures Core Web Vitals (LCP, INP, CLS) and supplementary metrics, identifies render-blocking resources and request chains, detects caching gaps and accessibility issues"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/web-perf"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/workers-best-practices/spec.yaml
+++ b/skills/workers-best-practices/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare workers-best-practices Skill
+# Review and author Workers code against production best practices.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/workers-best-practices:0.1.0
+
+metadata:
+  name: workers-best-practices
+  description: "Review and author Cloudflare Workers code against production best practices — streaming, floating promises, global state, secrets, bindings, observability, cryptographic randomness, type safety, wrangler config"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/workers-best-practices"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/wrangler/spec.yaml
+++ b/skills/wrangler/spec.yaml
@@ -1,0 +1,23 @@
+# Cloudflare wrangler Skill
+# Cloudflare Workers CLI — deploy, dev, manage bindings and resources.
+# Source: https://github.com/cloudflare/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/wrangler:0.1.0
+
+metadata:
+  name: wrangler
+  description: "Cloudflare Workers CLI — deploy, dev, and manage Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, and Secrets Store; wrangler.jsonc config patterns and binding shapes"
+
+spec:
+  repository: "https://github.com/cloudflare/skills"
+  ref: "0397d7d88fa6ac7517a88389622eb0799e86ded2"  # main as of 2026-04-16
+  path: "skills/wrangler"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/cloudflare/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "cloudflare/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Packages 8 Cloudflare platform skills from [`cloudflare/skills`](https://github.com/cloudflare/skills) (Apache-2.0) into Dockyard. All skills pinned to upstream commit [`0397d7d`](https://github.com/cloudflare/skills/commit/0397d7d88fa6ac7517a88389622eb0799e86ded2) (main as of 2026-04-16).

Fourth vendor in the per-vendor skills sweep. Cloudflare is an Anthropic skills launch partner.

Tracks #479.

### Skills added

**Agents and execution**
- `agents-sdk` — AI agents on Workers (state, callable RPC, workflows, MCP, chat, React hooks)
- `durable-objects` — stateful coordination with SQLite storage, alarms, WebSockets
- `sandbox-sdk` — secure code-execution sandboxes for AI interpreters and dev environments

**Platform**
- `cloudflare` — comprehensive umbrella skill with product decision trees (Workers, Pages, storage, AI, networking, security, IaC)
- `workers-best-practices` — production code review rules for Workers
- `wrangler` — CLI for Workers, KV, R2, D1, Vectorize, Hyperdrive, Workers AI, Containers, Queues, Workflows, Pipelines, Secrets Store

**Specialized**
- `cloudflare-email-service` — Email Sending + Email Routing (Workers binding, REST, Agents SDK)
- `web-perf` — Chrome DevTools MCP-powered Core Web Vitals audit

### Security allowlists

All 8 skills carry `MANIFEST_MISSING_LICENSE` (INFO) — upstream is Apache-2.0 at the repo root, not as SPDX in per-skill SKILL.md frontmatter.

The `cloudflare` umbrella skill additionally allowlists `EXCESSIVE_FILE_COUNT` (LOW): it ships 316 files organized as one `references/<product>/` subtree per Cloudflare product. The large file count is upstream's design — the skill functions as a product index that routes to the relevant reference for any Cloudflare task. All files are Cloudflare-authored documentation, not bundled dependencies.

## Test plan

- [x] `task validate-skill` on all 8 — all VALID
- [x] Cisco AI Defense skill-scanner 2.0.9 — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 8 OCI artifacts published

Closes #479