### PR TITLE
feat(skills): package 12 Hugging Face skills

### DIFF
--- a/skills/hf-cli/spec.yaml
+++ b/skills/hf-cli/spec.yaml
@@ -1,0 +1,25 @@
+# Hugging Face hf-cli Skill
+# Hugging Face Hub CLI (`hf`) for models, datasets, spaces, buckets, jobs, and more.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hf-cli:0.1.0
+
+metadata:
+  name: hf-cli
+  description: "Hugging Face Hub CLI (`hf`) — downloads, uploads, auth, cache, buckets, repos, discussions/PRs, models/datasets/spaces, papers, collections, jobs, inference endpoints, webhooks, extensions; replaces the deprecated huggingface-cli"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/hf-cli"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official `hf` CLI installer (`curl -LsSf https://hf.co/cli/install.sh | bash`) and the `hf-mount` installer (`curl -fsSL https://raw.githubusercontent.com/huggingface/hf-mount/main/install.sh | sh`) as documented install commands. The scanner itself flags both as 'instructional install text in SKILL.md'."

--- a/skills/hf-mcp/spec.yaml
+++ b/skills/hf-mcp/spec.yaml
@@ -1,0 +1,25 @@
+# Hugging Face hf-mcp Skill
+# Use Hugging Face Hub via MCP server tools.
+# Depends on: Hugging Face MCP server (packaged in toolhive-catalog under
+#   registries/official/servers/huggingface).
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hf-mcp:0.1.0
+
+metadata:
+  name: hf-mcp
+  description: "Use the Hugging Face Hub via MCP server tools — search models, datasets, Spaces, papers; get repo details, fetch docs, run compute jobs, use Gradio Spaces as AI tools (e.g., image generation, speech transcription)"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "hf-mcp/skills/hf-mcp"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-community-evals/spec.yaml
+++ b/skills/huggingface-community-evals/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face huggingface-community-evals Skill
+# Run evaluations for HF Hub models with inspect-ai or lighteval on local hardware.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-community-evals:0.1.0
+
+metadata:
+  name: huggingface-community-evals
+  description: "Run model evaluations against Hugging Face Hub models on local hardware with inspect-ai or lighteval — backend selection across vLLM, Transformers, and accelerate; smoke tests, task selection, and fallback strategy"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-community-evals"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-datasets/spec.yaml
+++ b/skills/huggingface-datasets/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face huggingface-datasets Skill
+# Hugging Face Dataset Viewer API workflows.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-datasets:0.1.0
+
+metadata:
+  name: huggingface-datasets
+  description: "Hugging Face Dataset Viewer API workflows — fetch subset/split metadata, paginate rows, search text, apply filters, download parquet URLs, read size and statistics; SQL queries via parquetlens"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-datasets"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-gradio/spec.yaml
+++ b/skills/huggingface-gradio/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face huggingface-gradio Skill
+# Build Gradio web UIs and demos in Python.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-gradio:0.1.0
+
+metadata:
+  name: huggingface-gradio
+  description: "Build Gradio web UIs and demos in Python — Interface, Blocks, ChatInterface, event listeners, layouts, custom HTML components, gradio CLI (info, predict) for programmatic Space interactions"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-gradio"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-llm-trainer/spec.yaml
+++ b/skills/huggingface-llm-trainer/spec.yaml
@@ -1,0 +1,34 @@
+# Hugging Face huggingface-llm-trainer Skill
+# Train/fine-tune language models with TRL or Unsloth on Hugging Face Jobs.
+# Depends on: Hugging Face MCP server (packaged in toolhive-catalog under
+#   registries/official/servers/huggingface) — uses hf_jobs, hf_whoami,
+#   hf_doc_search, hf_doc_fetch tools.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-llm-trainer:0.1.0
+
+metadata:
+  name: huggingface-llm-trainer
+  description: "Train or fine-tune language and vision models with TRL (SFT, DPO, GRPO, reward modeling) or Unsloth on Hugging Face Jobs cloud GPUs — dataset validation, hardware selection, cost estimation, Trackio monitoring, Hub persistence, GGUF conversion"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-llm-trainer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: TOOL_ABUSE_UNDECLARED_NETWORK
+      reason: "The skill orchestrates training jobs on Hugging Face Jobs cloud GPUs via the HF MCP server's `hf_jobs` tool. The network requirement is through the HF MCP server dependency (packaged in toolhive-catalog under registries/official/servers/huggingface), not a direct network-access tool in frontmatter."
+    - rule_id: SOCIAL_ENG_MISLEADING_DESC
+      reason: "Scanner heuristic flags the broad scope of the description (training SFT/DPO/GRPO + GGUF conversion + monitoring + etc.) as 'performing actions not reflected in description'. The description accurately reflects the skill's documented scope; the flag is a scanner conservatism false positive."
+    - rule_id: TOOL_ABUSE_SYSTEM_PACKAGE_INSTALL
+      reason: "The bundled `scripts/convert_to_gguf.py` references `sudo apt-get install` / `sudo yum install` for optional system packages (build tools) when converting trained models to GGUF format. These run in ephemeral HF Jobs containers, not on the user's host. The script is HF-authored and documented in SKILL.md."
+    - rule_id: DATA_EXFIL_NETWORK_REQUESTS
+      reason: "Bundled helper scripts (`scripts/dataset_inspector.py`, `scripts/hf_benchmarks.py`) use `urllib.request` to query the public Hugging Face Hub API for dataset validation and benchmark lookups — documented workflow steps required by the skill."

--- a/skills/huggingface-paper-publisher/spec.yaml
+++ b/skills/huggingface-paper-publisher/spec.yaml
@@ -1,0 +1,29 @@
+# Hugging Face huggingface-paper-publisher Skill
+# Publish and manage research papers on Hugging Face Hub.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-paper-publisher:0.1.0
+
+metadata:
+  name: huggingface-paper-publisher
+  description: "Publish and manage research papers on Hugging Face Hub — create paper pages, link papers to models/datasets/spaces, claim authorship, generate markdown research articles, manage citations and visibility"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-paper-publisher"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: DATA_EXFIL_NETWORK_REQUESTS
+      reason: "`scripts/paper_manager.py` uses `requests.get()` to query the public Hugging Face Hub API (`api.huggingface.co`) for paper metadata — the skill's entire purpose. The destinations are the official HF API endpoints documented in the SKILL.md workflow."
+    - rule_id: TOOL_ABUSE_UNDECLARED_NETWORK
+      reason: "The skill uses network access through its bundled `paper_manager.py` script (as its documented workflow), but does not declare an explicit network-access tool in frontmatter. All network calls target the public Hugging Face Hub API documented in the SKILL.md."
+    - rule_id: FILE_MAGIC_MISMATCH
+      reason: "`templates/modern.md` is a paper template that legitimately uses Handlebars-style `{{}}` substitution syntax. Magika detects the Handlebars markers and flags the format mismatch; the file is plain text documentation and safe."

--- a/skills/huggingface-papers/spec.yaml
+++ b/skills/huggingface-papers/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face huggingface-papers Skill
+# Look up and read Hugging Face paper pages and use the papers API.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-papers:0.1.0
+
+metadata:
+  name: huggingface-papers
+  description: "Look up and read Hugging Face paper pages in markdown and use the papers API — parse arXiv IDs from various URL forms, fetch structured metadata (authors, linked models/datasets/spaces, GitHub repo, project page), claim authorship, index papers"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-papers"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-tool-builder/spec.yaml
+++ b/skills/huggingface-tool-builder/spec.yaml
@@ -1,0 +1,29 @@
+# Hugging Face huggingface-tool-builder Skill
+# Build reusable scripts that use the Hugging Face API.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-tool-builder:0.1.0
+
+metadata:
+  name: huggingface-tool-builder
+  description: "Build reusable command-line scripts and utilities using the Hugging Face API and hf CLI — chains/pipes API calls, enriches model/dataset metadata, composable NDJSON output, HF_TOKEN auth hygiene"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-tool-builder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: DATA_EXFIL_NETWORK_REQUESTS
+      reason: "The skill's baseline reference scripts (`references/baseline_hf_api.py`) use `urllib.request.Request/urlopen` against the public Hugging Face Hub API (`api.huggingface.co`). Teaching users to build HF API-consuming tools is the skill's entire purpose."
+    - rule_id: TOOL_ABUSE_UNDECLARED_NETWORK
+      reason: "The skill uses network access through its bundled reference scripts that call the public Hugging Face Hub API. The frontmatter does not declare a dedicated network-access tool, but the network calls are documented examples bundled for user education, not runtime execution by the skill itself."
+    - rule_id: LOW_ANALYZABILITY
+      reason: "The scanner reports that 1 of 8 files is opaque — this is an executable `.tsx` reference script (`references/baseline_hf_api.tsx`) that the scanner cannot fully parse. The file is a small, HF-authored example script and is readable markdown-adjacent TypeScript."

--- a/skills/huggingface-trackio/spec.yaml
+++ b/skills/huggingface-trackio/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face huggingface-trackio Skill
+# Track and visualize ML training experiments with Trackio.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-trackio:0.1.0
+
+metadata:
+  name: huggingface-trackio
+  description: "Track and visualize ML training experiments with Trackio — log metrics via Python API, fire alerts for diagnostics (loss spikes, NaN gradients), retrieve metrics and alerts via CLI, sync to HF Spaces dashboards for autonomous experiment iteration"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-trackio"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/huggingface-vision-trainer/spec.yaml
+++ b/skills/huggingface-vision-trainer/spec.yaml
@@ -1,0 +1,31 @@
+# Hugging Face huggingface-vision-trainer Skill
+# Train vision models for object detection, classification, SAM segmentation on HF Jobs.
+# Depends on: Hugging Face MCP server (packaged in toolhive-catalog under
+#   registries/official/servers/huggingface) — uses hf_jobs, hf_whoami tools.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/huggingface-vision-trainer:0.1.0
+
+metadata:
+  name: huggingface-vision-trainer
+  description: "Train and fine-tune vision models on Hugging Face Jobs — object detection (D-FINE, RT-DETR v2, DETR), image classification (timm, MobileNet, ViT, DINOv3), SAM/SAM2 segmentation; COCO-format prep, Albumentations, mAP/accuracy metrics, DiceCE loss, Trackio monitoring"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/huggingface-vision-trainer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: TOOL_ABUSE_UNDECLARED_NETWORK
+      reason: "The skill orchestrates vision training jobs on Hugging Face Jobs cloud GPUs via the HF MCP server's `hf_jobs` tool. The network requirement is through the HF MCP server dependency (packaged in toolhive-catalog under registries/official/servers/huggingface), not a direct network-access tool in frontmatter."
+    - rule_id: SOCIAL_ENG_MISLEADING_DESC
+      reason: "Scanner heuristic flags the breadth of the description (object detection + image classification + SAM/SAM2 segmentation) as 'performing actions not reflected in description'. The description accurately reflects the skill's documented scope; the flag is a scanner conservatism false positive."
+    - rule_id: DATA_EXFIL_NETWORK_REQUESTS
+      reason: "The bundled `scripts/dataset_inspector.py` uses `urllib.request.urlopen()` to query the public Hugging Face Hub API for dataset format validation — a documented workflow step required before launching GPU training."

--- a/skills/transformers-js/spec.yaml
+++ b/skills/transformers-js/spec.yaml
@@ -1,0 +1,23 @@
+# Hugging Face transformers-js Skill
+# Run ML models in JavaScript/TypeScript with Transformers.js.
+# Source: https://github.com/huggingface/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/transformers-js:0.1.0
+
+metadata:
+  name: transformers-js
+  description: "Run ML models in JavaScript/TypeScript via Transformers.js — NLP, computer vision, audio, and multimodal tasks in browsers and Node.js/Bun/Deno with WebGPU/WASM; pipeline API, tokenizers, quantization (fp32/fp16/q8/q4), memory management"
+
+spec:
+  repository: "https://github.com/huggingface/skills"
+  ref: "061ab494cb145f43ae8f218939b99160e2c61c58"  # main as of 2026-04-16
+  path: "skills/transformers-js"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/huggingface/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "huggingface/skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Packages 12 Hugging Face platform skills from [`huggingface/skills`](https://github.com/huggingface/skills) (Apache-2.0) into Dockyard. All skills pinned to upstream commit [`061ab49`](https://github.com/huggingface/skills/commit/061ab494cb145f43ae8f218939b99160e2c61c58) (main as of 2026-04-16).

Fifth vendor in the per-vendor skills sweep.

Tracks #477.

### Skills added

**Tooling and CLIs**
- `hf-cli` — Hugging Face Hub CLI (`hf`) — replaces the deprecated `huggingface-cli`
- `huggingface-tool-builder` — build reusable HF API scripts via `hf` CLI and curl/REST
- `hf-mcp` — use the Hugging Face Hub via MCP server tools

**Hub content**
- `huggingface-datasets` — Dataset Viewer API workflows + parquetlens SQL
- `huggingface-papers` — read Hugging Face paper pages as markdown; papers API
- `huggingface-paper-publisher` — create, link, and claim papers on the Hub
- `huggingface-trackio` — experiment tracking with Trackio (logging, alerts, CLI)

**Frameworks**
- `huggingface-gradio` — build Gradio web UIs and demos in Python
- `transformers-js` — Transformers.js for browser/Node.js/Bun/Deno

**Evaluation and training**
- `huggingface-community-evals` — local evaluations via inspect-ai or lighteval
- `huggingface-llm-trainer` — TRL/Unsloth SFT/DPO/GRPO training on HF Jobs
- `huggingface-vision-trainer` — vision model training on HF Jobs (object detection, classification, SAM/SAM2)

### MCP server dependency

Three of these skills depend on the **Hugging Face MCP server** (`hf_jobs`, `hf_whoami`, `hf_doc_search`, `hf_doc_fetch`, etc.):
- `hf-mcp`
- `huggingface-llm-trainer`
- `huggingface-vision-trainer`

Per [`skill-criteria.md`](https://github.com/stacklok/toolhive-catalog/blob/main/docs/skill-criteria.md#mcp-server-dependencies), skills that depend on MCP servers are only eligible if the server is already in the ToolHive catalog. **The HF MCP server is packaged under `registries/official/servers/huggingface`** — the dependency is satisfied.

### Security allowlists

All 12 skills carry `MANIFEST_MISSING_LICENSE` (INFO) — upstream is Apache-2.0 at the repo root, not as SPDX in per-skill SKILL.md frontmatter.

Additional targeted allowlists, each documented inline with justification in the corresponding `spec.yaml`:

- **`hf-cli`** — `PIPELINE_TAINT_FLOW` (LOW): `curl | bash` installers for `hf` and `hf-mount` (flagged by scanner as "instructional").
- **`huggingface-paper-publisher`** — `DATA_EXFIL_NETWORK_REQUESTS`, `TOOL_ABUSE_UNDECLARED_NETWORK`, `FILE_MAGIC_MISMATCH` (Handlebars paper template).
- **`huggingface-tool-builder`** — `DATA_EXFIL_NETWORK_REQUESTS`, `TOOL_ABUSE_UNDECLARED_NETWORK`, `LOW_ANALYZABILITY` (baseline HF API reference scripts).
- **`huggingface-llm-trainer`** — `TOOL_ABUSE_UNDECLARED_NETWORK`, `SOCIAL_ENG_MISLEADING_DESC`, `TOOL_ABUSE_SYSTEM_PACKAGE_INSTALL` (apt/yum in GGUF conversion script inside ephemeral HF Jobs containers), `DATA_EXFIL_NETWORK_REQUESTS`.
- **`huggingface-vision-trainer`** — `TOOL_ABUSE_UNDECLARED_NETWORK`, `SOCIAL_ENG_MISLEADING_DESC`, `DATA_EXFIL_NETWORK_REQUESTS`.

## Test plan

- [x] `task validate-skill` on all 12 — all VALID
- [x] Cisco AI Defense skill-scanner 2.0.9 — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 12 OCI artifacts published under `ghcr.io/stacklok/dockyard/skills/<name>:0.1.0`

Closes #477