### PR TITLE
feat(skills): package 4 Google Gemini skills

### DIFF
--- a/skills/gemini-api-dev/spec.yaml
+++ b/skills/gemini-api-dev/spec.yaml
@@ -1,0 +1,23 @@
+# Gemini gemini-api-dev Skill
+# Build applications with the Gemini API and google-genai SDKs.
+# Source: https://github.com/google-gemini/gemini-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/gemini-api-dev:0.1.0
+
+metadata:
+  name: gemini-api-dev
+  description: "Build applications with the Gemini API — generate content, multimodal (text/image/audio/video), function calling, structured output; current models (Gemini 3.x) and SDKs (google-genai for Python, @google/genai for JS/TS, google.golang.org/genai for Go, com.google.genai:google-genai for Java)"
+
+spec:
+  repository: "https://github.com/google-gemini/gemini-skills"
+  ref: "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296"  # main as of 2026-03-27
+  path: "skills/gemini-api-dev"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/google-gemini/gemini-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "google-gemini/gemini-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/gemini-interactions-api/spec.yaml
+++ b/skills/gemini-interactions-api/spec.yaml
@@ -1,0 +1,23 @@
+# Gemini gemini-interactions-api Skill
+# Use the Gemini Interactions API — unified interface for models and agents.
+# Source: https://github.com/google-gemini/gemini-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/gemini-interactions-api:0.1.0
+
+metadata:
+  name: gemini-interactions-api
+  description: "Use the Gemini Interactions API — unified interface for models and agents with server-side conversation state (previous_interaction_id), streaming, background execution (Deep Research agent), and tool orchestration; supersedes generateContent for agentic applications"
+
+spec:
+  repository: "https://github.com/google-gemini/gemini-skills"
+  ref: "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296"  # main as of 2026-03-27
+  path: "skills/gemini-interactions-api"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/google-gemini/gemini-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "google-gemini/gemini-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/gemini-live-api-dev/spec.yaml
+++ b/skills/gemini-live-api-dev/spec.yaml
@@ -1,0 +1,23 @@
+# Gemini gemini-live-api-dev Skill
+# Build real-time bidirectional streaming applications with the Gemini Live API.
+# Source: https://github.com/google-gemini/gemini-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/gemini-live-api-dev:0.1.0
+
+metadata:
+  name: gemini-live-api-dev
+  description: "Build real-time, bidirectional streaming applications with the Gemini Live API — WebSocket-based audio/video/text streaming, voice activity detection, native audio, function calling, session management, ephemeral tokens for client-side auth"
+
+spec:
+  repository: "https://github.com/google-gemini/gemini-skills"
+  ref: "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296"  # main as of 2026-03-27
+  path: "skills/gemini-live-api-dev"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/google-gemini/gemini-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "google-gemini/gemini-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/vertex-ai-api-dev/spec.yaml
+++ b/skills/vertex-ai-api-dev/spec.yaml
@@ -1,0 +1,23 @@
+# Gemini vertex-ai-api-dev Skill
+# Use the Gemini API on Google Cloud Vertex AI for enterprise workloads.
+# Source: https://github.com/google-gemini/gemini-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/vertex-ai-api-dev:0.1.0
+
+metadata:
+  name: vertex-ai-api-dev
+  description: "Use the Gemini API on Google Cloud Vertex AI for enterprise workloads — unified Gen AI SDK (Python, JS/TS, Go, Java, C#/.NET), Live API, function calling, structured output, context caching, embeddings, batch prediction; ADC and Express Mode auth"
+
+spec:
+  repository: "https://github.com/google-gemini/gemini-skills"
+  ref: "5b655a47ac6d03a2d96d6e64ca051b6a7fe62296"  # main as of 2026-03-27
+  path: "skills/vertex-ai-api-dev"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/google-gemini/gemini-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "google-gemini/gemini-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Packages 4 Gemini API development skills from [`google-gemini/gemini-skills`](https://github.com/google-gemini/gemini-skills) (Apache-2.0) into Dockyard. All skills pinned to upstream commit [`5b655a4`](https://github.com/google-gemini/gemini-skills/commit/5b655a47ac6d03a2d96d6e64ca051b6a7fe62296) (main as of 2026-03-27).

Sixth vendor in the per-vendor skills sweep. Complements Dockyard's existing Anthropic `claude-api` skill.

Tracks #480.

### Skills added

- `gemini-api-dev` — Gemini API (content generation, multimodal, function calling, structured output) with `google-genai` SDKs across Python, JS/TS, Go, and Java
- `gemini-interactions-api` — Interactions API: unified model+agent interface with server-side conversation state, streaming, and background Deep Research agent
- `gemini-live-api-dev` — Live API: real-time bidirectional WebSocket audio/video/text streaming, VAD, native audio, session management, ephemeral tokens
- `vertex-ai-api-dev` — Gemini on Google Cloud Vertex AI: enterprise Gen AI SDK across Python, JS/TS, Go, Java, and C#/.NET

### MCP dependency note

All four skills mention the "Google MCP" / "Developer Knowledge MCP" server as an **optional** documentation lookup enhancement. Each SKILL.md explicitly provides a "When MCP is NOT Installed (Fallback Only)" path that fetches documentation from `ai.google.dev` via URL. There is no hard MCP dependency declared in frontmatter `allowed-tools`, so these are eligible per [`skill-criteria.md`](https://github.com/stacklok/toolhive-catalog/blob/main/docs/skill-criteria.md#mcp-server-dependencies).

### Security allowlists

All 4 skills carry `MANIFEST_MISSING_LICENSE` (INFO) — upstream is Apache-2.0 at the repo root, not as SPDX in per-skill SKILL.md frontmatter. No other scanner findings on any of the 4.

## Test plan

- [x] `task validate-skill` on all 4 — all VALID
- [x] Cisco AI Defense skill-scanner 2.0.9 — all pass after allowlist
- [ ] CI: `Build Skill Artifacts` workflow succeeds
- [ ] CI: `skill-scan-report` surfaces only allowlisted findings
- [ ] Post-merge: 4 OCI artifacts published

Closes #480