### PR TITLE
feat(skills): package 2 Supabase skills

### DIFF
--- a/skills/supabase-postgres-best-practices/spec.yaml
+++ b/skills/supabase-postgres-best-practices/spec.yaml
@@ -1,0 +1,23 @@
+# Supabase supabase-postgres-best-practices Skill
+# Postgres performance optimization and best practices from Supabase.
+# Source: https://github.com/supabase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/supabase-postgres-best-practices:0.1.0
+
+metadata:
+  name: supabase-postgres-best-practices
+  description: "Postgres performance optimization and best practices from Supabase — rules across query performance, connection management, security/RLS, schema design, concurrency/locking, data access patterns, monitoring, and advanced features"
+
+spec:
+  repository: "https://github.com/supabase/agent-skills"
+  ref: "3e7fd16bf8cab06d3c24dc775a331e6effcba29a"  # main as of 2026-04-19
+  path: "skills/supabase-postgres-best-practices"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/supabase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "supabase/agent-skills is licensed MIT at the repository root; the skill does embed `license: MIT` in frontmatter, but the scanner may flag the missing SPDX-to-file-match — this entry is kept for consistency across the vendor."

--- a/skills/supabase/spec.yaml
+++ b/skills/supabase/spec.yaml
@@ -1,0 +1,25 @@
+# Supabase supabase Skill
+# Use this skill for ANY Supabase task — products, clients, auth, schema changes, security.
+# Depends on (optional): Supabase MCP server (packaged in toolhive-catalog under
+#   registries/*/servers/supabase and dockyard npx/supabase-mcp-server).
+# Source: https://github.com/supabase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/supabase:0.1.0
+
+metadata:
+  name: supabase
+  description: "Use for any Supabase task — Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues; supabase-js and @supabase/ssr SSR integrations; RLS-by-default security checklist, schema changes, migrations, Postgres extensions, CLI, MCP server troubleshooting"
+
+spec:
+  repository: "https://github.com/supabase/agent-skills"
+  ref: "3e7fd16bf8cab06d3c24dc775a331e6effcba29a"  # main as of 2026-04-19
+  path: "skills/supabase"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/supabase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "supabase/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 2 skills from [`supabase/agent-skills`](https://github.com/supabase/agent-skills) (MIT), pinned to [`3e7fd16`](https://github.com/supabase/agent-skills/commit/3e7fd16bf8cab06d3c24dc775a331e6effcba29a).

### Skills added
- `supabase` — full product skill (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); RLS-by-default security checklist, migrations workflow, CLI and MCP troubleshooting
- `supabase-postgres-best-practices` — Postgres performance and schema rules across 8 categories

### MCP dependency
The `supabase` skill references the Supabase MCP server (optional tool calls with documented fetch-URL/CLI fallbacks). **The Supabase MCP server is packaged** in the toolhive catalog (`registries/*/servers/supabase`) and in dockyard (`npx/supabase-mcp-server`), so the dependency is satisfied per skill-criteria.md.

### Security allowlists
Both carry `MANIFEST_MISSING_LICENSE` (INFO) — upstream MIT at repo root; `supabase-postgres-best-practices` does have `license: MIT` in frontmatter but the scanner's SPDX check is kept allowlisted for consistency.

### Test plan
- [x] `task validate-skill` on both — all VALID
- [x] `task scan-skill` passes
- [ ] CI green
- [ ] 2 OCI artifacts published

Closes #488