### PR TITLE
feat(skills): package 2 Weaviate skills

### DIFF
--- a/skills/weaviate-cookbooks/spec.yaml
+++ b/skills/weaviate-cookbooks/spec.yaml
@@ -1,0 +1,25 @@
+# Weaviate weaviate-cookbooks Skill
+# Architectural patterns and blueprints for Weaviate-powered AI applications.
+# Source: https://github.com/weaviate/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/weaviate-cookbooks:0.1.0
+
+metadata:
+  name: weaviate-cookbooks
+  description: "Architectural patterns and blueprints for Weaviate-powered AI apps — Query Agent Chatbot, Data Explorer, Multimodal PDF RAG, basic/advanced RAG, basic agent and agentic RAG, optional frontend; async client guidance"
+
+spec:
+  repository: "https://github.com/weaviate/agent-skills"
+  ref: "2f62f9fb7784ce57cb182ad6e575310f280a6b63"  # main as of 2026-04-01
+  path: "skills/weaviate-cookbooks"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/weaviate/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "weaviate/agent-skills is licensed BSD-3-Clause at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The cookbook references the official `astral.sh/uv` and `ollama.com` installers (`curl | sh`) as documented prerequisites for running the RAG/agent cookbook examples. The scanner itself flags both as 'well-known installer URL' / 'instructional rather than executable'."

--- a/skills/weaviate/spec.yaml
+++ b/skills/weaviate/spec.yaml
@@ -1,0 +1,25 @@
+# Weaviate weaviate Skill
+# Search, query, and manage Weaviate vector database collections.
+# Source: https://github.com/weaviate/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/weaviate:0.1.0
+
+metadata:
+  name: weaviate
+  description: "Search, query, and manage Weaviate vector database collections — semantic, hybrid, and keyword search; Query Agent (ask/search modes); collection schema management; data imports from PDF/CSV/JSON/JSONL; example-data seeding"
+
+spec:
+  repository: "https://github.com/weaviate/agent-skills"
+  ref: "2f62f9fb7784ce57cb182ad6e575310f280a6b63"  # main as of 2026-04-01
+  path: "skills/weaviate"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/weaviate/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "weaviate/agent-skills is licensed BSD-3-Clause at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: TOOL_ABUSE_SYSTEM_PACKAGE_INSTALL
+      reason: "The skill's PDF-import helper references an `apt-get install` command for OCR/PDF system dependencies as documentation. The command runs only when the user explicitly performs a PDF import; documented in SKILL.md."


### PR DESCRIPTION
Packages 2 skills from [`weaviate/agent-skills`](https://github.com/weaviate/agent-skills) (BSD-3-Clause), pinned to [`2f62f9f`](https://github.com/weaviate/agent-skills/commit/2f62f9fb7784ce57cb182ad6e575310f280a6b63).

### Skills added
- `weaviate` — vector DB operations (semantic, hybrid, keyword search; Query Agent; collection management; PDF/CSV/JSON imports)
- `weaviate-cookbooks` — AI-application blueprints (Query Agent Chatbot, Data Explorer, Multimodal RAG, Basic/Advanced RAG, Basic Agent, Agentic RAG)

### Security allowlists
- `MANIFEST_MISSING_LICENSE` (INFO): upstream BSD-3-Clause at repo root, no per-skill SPDX.
- `weaviate`: `TOOL_ABUSE_SYSTEM_PACKAGE_INSTALL` (`apt-get install` for PDF OCR dependencies).
- `weaviate-cookbooks`: `PIPELINE_TAINT_FLOW` (documented `uv` and `ollama` installer `curl | sh` commands; scanner itself flags as 'well-known installer').

### Test plan
- [x] `task validate-skill` on both — VALID
- [x] `task scan-skill` passes after allowlist
- [ ] CI green
- [ ] 2 OCI artifacts published

Closes #493