### PR TITLE
feat(skills): package 3 Stripe skills

### DIFF
--- a/skills/stripe-best-practices/spec.yaml
+++ b/skills/stripe-best-practices/spec.yaml
@@ -1,0 +1,23 @@
+# Stripe stripe-best-practices Skill
+# Guides Stripe integration decisions — API selection, Connect, Billing, security.
+# Source: https://github.com/stripe/agent-toolkit
+# Will publish as: ghcr.io/stacklok/dockyard/skills/stripe-best-practices:0.1.0
+
+metadata:
+  name: stripe-best-practices
+  description: "Stripe integration decisions — API selection (Checkout Sessions vs PaymentIntents), Connect platform (Accounts v2), Billing/Subscriptions, Treasury financial accounts, Checkout/Payment Element, migration from deprecated APIs, and security best practices (restricted keys, webhooks, OAuth)"
+
+spec:
+  repository: "https://github.com/stripe/agent-toolkit"
+  ref: "dd6deb03137908d0102ffde97e60c90cf79bf929"  # main as of 2026-04-16
+  path: "skills/stripe-best-practices"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/stripe/agent-toolkit"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "stripe/agent-toolkit is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/stripe-projects/spec.yaml
+++ b/skills/stripe-projects/spec.yaml
@@ -1,0 +1,23 @@
+# Stripe stripe-projects Skill
+# Set up a new app with Stripe Projects CLI for software-stack provisioning.
+# Source: https://github.com/stripe/agent-toolkit
+# Will publish as: ghcr.io/stacklok/dockyard/skills/stripe-projects:0.1.0
+
+metadata:
+  name: stripe-projects
+  description: "Set up a new app or local repo with Stripe Projects — CLI-driven software-stack provisioning (`stripe projects init`) for bootstrapping Stripe integrations from a coding agent"
+
+spec:
+  repository: "https://github.com/stripe/agent-toolkit"
+  ref: "dd6deb03137908d0102ffde97e60c90cf79bf929"  # main as of 2026-04-16
+  path: "skills/stripe-projects"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/stripe/agent-toolkit"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "stripe/agent-toolkit is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/upgrade-stripe/spec.yaml
+++ b/skills/upgrade-stripe/spec.yaml
@@ -1,0 +1,23 @@
+# Stripe upgrade-stripe Skill
+# Guide for upgrading Stripe API versions and SDKs.
+# Source: https://github.com/stripe/agent-toolkit
+# Will publish as: ghcr.io/stacklok/dockyard/skills/upgrade-stripe:0.1.0
+
+metadata:
+  name: upgrade-stripe
+  description: "Upgrade Stripe API versions and SDKs — server-side SDK version management (Ruby, Python, PHP, Node.js, Java, Go, .NET), Stripe.js versioning, mobile SDK migration, API Changelog review, and staged adoption via Stripe-Version header"
+
+spec:
+  repository: "https://github.com/stripe/agent-toolkit"
+  ref: "dd6deb03137908d0102ffde97e60c90cf79bf929"  # main as of 2026-04-16
+  path: "skills/upgrade-stripe"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/stripe/agent-toolkit"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "stripe/agent-toolkit is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 3 skills from [`stripe/agent-toolkit`](https://github.com/stripe/agent-toolkit) (MIT), pinned to [`dd6deb0`](https://github.com/stripe/agent-toolkit/commit/dd6deb03137908d0102ffde97e60c90cf79bf929).

### Skills added
- `stripe-best-practices` — integration decisions (API selection, Connect, Billing, Treasury, security)
- `stripe-projects` — CLI-driven software-stack provisioning
- `upgrade-stripe` — server-side SDK, Stripe.js, and mobile SDK upgrade guide

### Security
All 3 carry only `MANIFEST_MISSING_LICENSE` (INFO). No other scanner findings.

### Test plan
- [x] `task validate-skill` on all 3 — VALID
- [x] `task scan-skill` passes
- [ ] CI green
- [ ] 3 OCI artifacts published

Closes #489