### PR TITLE
feat(skills): package 3 Neon skills

### DIFF
--- a/skills/claimable-postgres/spec.yaml
+++ b/skills/claimable-postgres/spec.yaml
@@ -1,0 +1,23 @@
+# Neon claimable-postgres Skill
+# Provision instant temporary Postgres databases via Claimable Postgres (neon.new).
+# Source: https://github.com/neondatabase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/claimable-postgres:0.1.0
+
+metadata:
+  name: claimable-postgres
+  description: "Provision instant temporary Postgres databases via Claimable Postgres by Neon (neon.new) — no login/signup/credit card, REST API/CLI/SDK/Vite plugin; ideal for prototyping, tests, and quick DATABASE_URLs; 72-hour claim window"
+
+spec:
+  repository: "https://github.com/neondatabase/agent-skills"
+  ref: "38c7da85db656c8c9efd1e6433c200212926fd2d"  # main as of 2026-04-14
+  path: "skills/claimable-postgres"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/neondatabase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "neondatabase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/neon-postgres-egress-optimizer/spec.yaml
+++ b/skills/neon-postgres-egress-optimizer/spec.yaml
@@ -1,0 +1,23 @@
+# Neon neon-postgres-egress-optimizer Skill
+# Diagnose and fix excessive Postgres egress (network data transfer).
+# Source: https://github.com/neondatabase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/neon-postgres-egress-optimizer:0.1.0
+
+metadata:
+  name: neon-postgres-egress-optimizer
+  description: "Diagnose and fix excessive Postgres egress — identify top offenders with pg_stat_statements, spot SELECT *, missing pagination, high-frequency queries on static data, app-side aggregation, and JOIN duplication; fix patterns with concrete SQL refactors"
+
+spec:
+  repository: "https://github.com/neondatabase/agent-skills"
+  ref: "38c7da85db656c8c9efd1e6433c200212926fd2d"  # main as of 2026-04-14
+  path: "skills/neon-postgres-egress-optimizer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/neondatabase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "neondatabase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/neon-postgres/spec.yaml
+++ b/skills/neon-postgres/spec.yaml
@@ -1,0 +1,23 @@
+# Neon neon-postgres Skill
+# Guides and best practices for working with Neon Serverless Postgres.
+# Source: https://github.com/neondatabase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/neon-postgres:0.1.0
+
+metadata:
+  name: neon-postgres
+  description: "Work with Neon Serverless Postgres — connection methods (serverless driver, PostgREST-style Data API), Neon CLI, MCP server setup, branching, autoscaling, scale-to-zero, instant restore, read replicas, connection pooling, logical replication; Platform API/SDKs in TypeScript and Python"
+
+spec:
+  repository: "https://github.com/neondatabase/agent-skills"
+  ref: "38c7da85db656c8c9efd1e6433c200212926fd2d"  # main as of 2026-04-14
+  path: "skills/neon-postgres"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/neondatabase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "neondatabase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 3 skills from [`neondatabase/agent-skills`](https://github.com/neondatabase/agent-skills) (Apache-2.0), pinned to [`38c7da8`](https://github.com/neondatabase/agent-skills/commit/38c7da85db656c8c9efd1e6433c200212926fd2d).

### Skills added
- `neon-postgres` — Neon Serverless Postgres guide (connection methods, drivers, CLI, branching, autoscaling, scale-to-zero, replicas)
- `claimable-postgres` — instant temporary Postgres databases via neon.new (REST/CLI/SDK/Vite plugin paths)
- `neon-postgres-egress-optimizer` — diagnose/fix high egress bills with pg_stat_statements and query refactors

### Security
All 3 carry only `MANIFEST_MISSING_LICENSE` (INFO). No other scanner findings.

### Test plan
- [x] `task validate-skill` on all 3 — VALID
- [x] `task scan-skill` passes
- [ ] CI green
- [ ] 3 OCI artifacts published

Closes #486