### PR TITLE
feat(skills): package 7 Pinecone skills

### DIFF
--- a/skills/pinecone-assistant/spec.yaml
+++ b/skills/pinecone-assistant/spec.yaml
@@ -1,0 +1,23 @@
+# Pinecone pinecone-assistant Skill
+# Create, manage, and chat with Pinecone Assistants for document Q&A.
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-assistant:0.1.0
+
+metadata:
+  name: pinecone-assistant
+  description: "Create, manage, and chat with Pinecone Assistants for document Q&A with citations — fully managed RAG (create, upload, sync, chat, context retrieval, list) via bundled uv-run Python scripts"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-assistant"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-cli/spec.yaml
+++ b/skills/pinecone-cli/spec.yaml
@@ -1,0 +1,23 @@
+# Pinecone pinecone-cli Skill
+# Manage Pinecone resources from the terminal with the `pc` CLI.
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-cli:0.1.0
+
+metadata:
+  name: pinecone-cli
+  description: "Use the Pinecone CLI (`pc`) to manage Pinecone resources from the terminal — supports all index types (standard, integrated, sparse) and all vector operations; backups, namespaces, CI/CD automation"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-cli"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-docs/spec.yaml
+++ b/skills/pinecone-docs/spec.yaml
@@ -1,0 +1,23 @@
+# Pinecone pinecone-docs Skill
+# Curated documentation reference index for developers building with Pinecone.
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-docs:0.1.0
+
+metadata:
+  name: pinecone-docs
+  description: "Curated Pinecone documentation reference — organized links by topic (getting started, indexes, upsert, search, production) and data format references for vectors and records"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-docs"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-help/spec.yaml
+++ b/skills/pinecone-help/spec.yaml
@@ -1,0 +1,23 @@
+# Pinecone pinecone-help Skill
+# Overview of available Pinecone skills and getting-started essentials.
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-help:0.1.0
+
+metadata:
+  name: pinecone-help
+  description: "Overview of available Pinecone skills and getting-started essentials — what a user needs (account, API key, optional CLI/MCP/uv) and which skill to use for each Pinecone task"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-help"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-mcp/spec.yaml
+++ b/skills/pinecone-mcp/spec.yaml
@@ -1,0 +1,25 @@
+# Pinecone pinecone-mcp Skill
+# Reference for the Pinecone MCP server tools.
+# Depends on: Pinecone MCP server (packaged in toolhive-catalog under
+#   registries/*/servers/pinecone; dockyard ghcr.io/stacklok/dockyard/npx/pinecone-mcp).
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-mcp:0.1.0
+
+metadata:
+  name: pinecone-mcp
+  description: "Reference for the Pinecone MCP server tools — list-indexes, describe-index, describe-index-stats, create-index-for-model, upsert-records, search-records, cascading-search, rerank-documents, search-docs"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-mcp"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-query/spec.yaml
+++ b/skills/pinecone-query/spec.yaml
@@ -1,0 +1,24 @@
+# Pinecone pinecone-query Skill
+# Query Pinecone integrated indexes using text via the Pinecone MCP server.
+# Depends on: Pinecone MCP server (packaged in toolhive-catalog).
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-query:0.1.0
+
+metadata:
+  name: pinecone-query
+  description: "Query Pinecone integrated indexes using natural-language text via the Pinecone MCP — search-records with filtering and reranking; interactive argument resolution via list-indexes and describe-index when the user omits required fields"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-query"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pinecone-quickstart/spec.yaml
+++ b/skills/pinecone-quickstart/spec.yaml
@@ -1,0 +1,24 @@
+# Pinecone pinecone-quickstart Skill
+# Interactive quickstart for new Pinecone developers.
+# Depends on: Pinecone MCP server (packaged in toolhive-catalog).
+# Source: https://github.com/pinecone-io/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pinecone-quickstart:0.1.0
+
+metadata:
+  name: pinecone-quickstart
+  description: "Interactive Pinecone quickstart — two paths: Database (create integrated index, upsert sample data, semantic search via Pinecone MCP + Python) or Assistant (document Q&A via Pinecone Assistant)"
+
+spec:
+  repository: "https://github.com/pinecone-io/skills"
+  ref: "787cd274ffeae942c9dcd693eadb86bafcacca19"  # main as of 2026-03-11
+  path: "skills/pinecone-quickstart"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pinecone-io/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pinecone-io/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 7 skills from [`pinecone-io/skills`](https://github.com/pinecone-io/skills) (MIT), pinned to [`787cd27`](https://github.com/pinecone-io/skills/commit/787cd274ffeae942c9dcd693eadb86bafcacca19).

### Skills added

**Non-MCP-dependent (4)**
- `pinecone-assistant` — managed RAG service (create, upload, sync, chat)
- `pinecone-cli` — terminal-based index and vector management (`pc` CLI)
- `pinecone-docs` — curated docs reference
- `pinecone-help` — skills overview and getting-started essentials

**MCP-dependent (3)** — see dependency note below
- `pinecone-mcp` — Pinecone MCP server tools reference
- `pinecone-query` — natural-language query via `search-records`
- `pinecone-quickstart` — two-path onboarding (Database via MCP, Assistant)

### MCP dependency

The three MCP-dependent skills depend on the **Pinecone MCP server** (`@pinecone-database/mcp`). That server is being added in parallel PRs:
- **Dockyard container**: [stacklok/dockyard#509](https://github.com/stacklok/dockyard/pull/509) — publishes `ghcr.io/stacklok/dockyard/npx/pinecone-mcp:0.2.1`
- **ToolHive catalog**: [stacklok/toolhive-catalog#1103](https://github.com/stacklok/toolhive-catalog/pull/1103) — registers the server under `registries/{official,toolhive}/servers/pinecone/`

**Merge order**: this PR depends on the catalog PR (#1103) merging first to satisfy the `skill-criteria.md` MCP-dependency requirement. The dockyard MCP container PR (#509) can merge in any order but should land before the catalog PR references the pinned image digest.

### Security
All 7 carry only `MANIFEST_MISSING_LICENSE` (INFO). No other findings.

### Test plan
- [x] `task validate-skill` on all 7 — VALID
- [x] `task scan-skill` passes
- [ ] CI green
- [ ] 7 OCI artifacts published

Closes #495