### PR TITLE
feat(skills): package 7 MongoDB skills

### DIFF
--- a/skills/atlas-stream-processing/spec.yaml
+++ b/skills/atlas-stream-processing/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB atlas-stream-processing Skill
+# Build real-time stream processing pipelines with MongoDB Atlas.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/atlas-stream-processing:0.1.0
+
+metadata:
+  name: atlas-stream-processing
+  description: "Build real-time stream processing pipelines with MongoDB Atlas Stream Processing — continuous queries over Kafka and MongoDB sources, windowing, aggregations, and enrichment"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/atlas-stream-processing"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-connection/spec.yaml
+++ b/skills/mongodb-connection/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB mongodb-connection Skill
+# Configure MongoDB connections across drivers and deployment targets.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-connection:0.1.0
+
+metadata:
+  name: mongodb-connection
+  description: "Configure MongoDB connections across drivers and deployment targets — connection strings, TLS, auth (SCRAM, X.509, AWS IAM), replica sets, pooling, serverless, and troubleshooting patterns"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-connection"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-mcp-setup/spec.yaml
+++ b/skills/mongodb-mcp-setup/spec.yaml
@@ -1,0 +1,25 @@
+# MongoDB mongodb-mcp-setup Skill
+# Set up the MongoDB MCP server in an agent environment.
+# Depends on: MongoDB MCP server (packaged in toolhive-catalog under
+#   registries/*/servers/mongodb).
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-mcp-setup:0.1.0
+
+metadata:
+  name: mongodb-mcp-setup
+  description: "Set up the MongoDB MCP server — install, authenticate, configure tools and scopes; guided integration with Claude Code, Cursor, and other MCP-compatible agents"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-mcp-setup"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-natural-language-querying/spec.yaml
+++ b/skills/mongodb-natural-language-querying/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB mongodb-natural-language-querying Skill
+# Translate natural language to MongoDB queries and aggregations.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-natural-language-querying:0.1.0
+
+metadata:
+  name: mongodb-natural-language-querying
+  description: "Translate natural-language requests into MongoDB queries and aggregations — schema-aware query generation, aggregation pipeline stages, and index-aware plan hints"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-natural-language-querying"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-query-optimizer/spec.yaml
+++ b/skills/mongodb-query-optimizer/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB mongodb-query-optimizer Skill
+# Analyze and optimize MongoDB queries and aggregation pipelines.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-query-optimizer:0.1.0
+
+metadata:
+  name: mongodb-query-optimizer
+  description: "Analyze and optimize MongoDB queries and aggregation pipelines — explain plans, index design, stage ordering, covered queries, and performance anti-patterns"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-query-optimizer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-schema-design/spec.yaml
+++ b/skills/mongodb-schema-design/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB mongodb-schema-design Skill
+# Design effective MongoDB schemas using document modeling patterns.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-schema-design:0.1.0
+
+metadata:
+  name: mongodb-schema-design
+  description: "Design effective MongoDB schemas — document modeling patterns (embedding, referencing, bucketing, polymorphism, extended reference), cardinality trade-offs, and index strategy"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-schema-design"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/mongodb-search-and-ai/spec.yaml
+++ b/skills/mongodb-search-and-ai/spec.yaml
@@ -1,0 +1,23 @@
+# MongoDB mongodb-search-and-ai Skill
+# Build Atlas Search and vector-search (AI) workloads on MongoDB.
+# Source: https://github.com/mongodb/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/mongodb-search-and-ai:0.1.0
+
+metadata:
+  name: mongodb-search-and-ai
+  description: "Build Atlas Search and vector-search AI workloads on MongoDB — full-text search, vector indexes, hybrid search, RAG patterns, embedding providers, and query tuning"
+
+spec:
+  repository: "https://github.com/mongodb/agent-skills"
+  ref: "eba6ae3f673baecb38d8ecd9df3ea4ce1f254443"  # main as of 2026-04-07
+  path: "skills/mongodb-search-and-ai"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mongodb/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mongodb/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 7 skills from [`mongodb/agent-skills`](https://github.com/mongodb/agent-skills) (Apache-2.0), pinned to [`eba6ae3`](https://github.com/mongodb/agent-skills/commit/eba6ae3f673baecb38d8ecd9df3ea4ce1f254443).

### Skills added
- `atlas-stream-processing` — real-time stream processing pipelines
- `mongodb-connection` — connection strings, TLS, auth across drivers
- `mongodb-mcp-setup` — guided setup of the MongoDB MCP server
- `mongodb-natural-language-querying` — NL-to-query and aggregation
- `mongodb-query-optimizer` — explain plans, indexes, anti-patterns
- `mongodb-schema-design` — document modeling patterns
- `mongodb-search-and-ai` — Atlas Search, vector search, RAG

### MCP dependency
`mongodb-mcp-setup` references the MongoDB MCP server. **MongoDB MCP is in the catalog** (`registries/*/servers/mongodb`), so the dependency is satisfied.

### Security
All 7 carry only `MANIFEST_MISSING_LICENSE` (INFO). No other findings.

### Test plan
- [x] `task validate-skill` on all 7 — VALID
- [x] `task scan-skill` passes
- [ ] CI green
- [ ] 7 OCI artifacts published

Closes #483