### PR TITLE
feat(skills): package 3 Atlassian Forge skills

### DIFF
--- a/skills/forge-app-builder/spec.yaml
+++ b/skills/forge-app-builder/spec.yaml
@@ -1,0 +1,27 @@
+# Atlassian forge-app-builder Skill
+# Build Atlassian Forge apps end-to-end.
+# Source: https://github.com/atlassian/forge-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/forge-app-builder:0.1.0
+
+metadata:
+  name: forge-app-builder
+  description: "Build Atlassian Forge apps end-to-end — app scaffolding via Forge CLI, manifest config, UI components (UI Kit, Custom UI, Forge React), backend resolvers and functions, triggers, scheduled triggers, permissions, and deployment"
+
+spec:
+  repository: "https://github.com/atlassian/forge-skills"
+  ref: "0d60ac5436dcb63af0869e110728f40e61274924"  # main as of 2026-04-19
+  path: "skills/forge-app-builder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/atlassian/forge-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "atlassian/forge-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: DATA_EXFIL_NETWORK_REQUESTS
+      reason: "`scripts/list_templates.py` uses `urllib.request.urlopen()` to fetch the official Forge app template index from Atlassian — documented workflow step for scaffolding new apps."
+    - rule_id: TOOL_ABUSE_UNDECLARED_NETWORK
+      reason: "The skill's bundled `list_templates.py` fetches Atlassian's Forge template catalog; the skill does not declare a dedicated network-access tool but the network call is for a documented, trusted destination."

--- a/skills/forge-app-review/spec.yaml
+++ b/skills/forge-app-review/spec.yaml
@@ -1,0 +1,23 @@
+# Atlassian forge-app-review Skill
+# Review Atlassian Forge apps for quality, security, and marketplace readiness.
+# Source: https://github.com/atlassian/forge-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/forge-app-review:0.1.0
+
+metadata:
+  name: forge-app-review
+  description: "Review Atlassian Forge apps for quality, security, and marketplace readiness — manifest and permission audit, resolver security, UI patterns, error handling, and Marketplace submission checklist"
+
+spec:
+  repository: "https://github.com/atlassian/forge-skills"
+  ref: "0d60ac5436dcb63af0869e110728f40e61274924"  # main as of 2026-04-19
+  path: "skills/forge-app-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/atlassian/forge-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "atlassian/forge-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/forge-debugger/spec.yaml
+++ b/skills/forge-debugger/spec.yaml
@@ -1,0 +1,23 @@
+# Atlassian forge-debugger Skill
+# Debug Atlassian Forge apps.
+# Source: https://github.com/atlassian/forge-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/forge-debugger:0.1.0
+
+metadata:
+  name: forge-debugger
+  description: "Debug Atlassian Forge apps — inspect logs, tunnel to local dev, trace resolver errors, reproduce webhook/trigger failures, verify manifest and permission scopes"
+
+spec:
+  repository: "https://github.com/atlassian/forge-skills"
+  ref: "0d60ac5436dcb63af0869e110728f40e61274924"  # main as of 2026-04-19
+  path: "skills/forge-debugger"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/atlassian/forge-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "atlassian/forge-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 3 skills from [`atlassian/forge-skills`](https://github.com/atlassian/forge-skills) (Apache-2.0), pinned to [`0d60ac5`](https://github.com/atlassian/forge-skills/commit/0d60ac5436dcb63af0869e110728f40e61274924).

### Skills added
- `forge-app-builder` — scaffold, build, and deploy Forge apps
- `forge-app-review` — quality/security/marketplace-readiness review
- `forge-debugger` — logs, tunnel, resolver/webhook diagnostics

Atlassian is an Anthropic skills launch partner.

### Security allowlists
`forge-app-builder` allowlists `DATA_EXFIL_NETWORK_REQUESTS` and `TOOL_ABUSE_UNDECLARED_NETWORK` for `list_templates.py` — official Atlassian template catalog fetch.

### Test plan
- [x] `task validate-skill` — VALID
- [x] `task scan-skill` passes after allowlist
- [ ] CI green
- [ ] 3 OCI artifacts published

Closes #494