### PR TITLE
feat(skills): package 2 LlamaIndex skills

### DIFF
--- a/skills/liteparse/spec.yaml
+++ b/skills/liteparse/spec.yaml
@@ -1,0 +1,23 @@
+# LlamaIndex liteparse Skill
+# Use LlamaIndex's lightweight document-parsing pipeline.
+# Source: https://github.com/run-llama/llamaparse-agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/liteparse:0.1.0
+
+metadata:
+  name: liteparse
+  description: "Use LlamaIndex's lightweight liteparse document parser — extract text and structure from PDFs and other documents without the full LlamaParse cloud dependency"
+
+spec:
+  repository: "https://github.com/run-llama/llamaparse-agent-skills"
+  ref: "1f10f60a9eba0dbb490724c8104b0a865365f136"  # main as of 2026-03-03
+  path: "skills/liteparse"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/run-llama/llamaparse-agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "run-llama/llamaparse-agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/llamaparse/spec.yaml
+++ b/skills/llamaparse/spec.yaml
@@ -1,0 +1,25 @@
+# LlamaIndex llamaparse Skill
+# Parse complex documents with LlamaParse.
+# Source: https://github.com/run-llama/llamaparse-agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/llamaparse:0.1.0
+
+metadata:
+  name: llamaparse
+  description: "Parse complex documents with LlamaParse — PDFs, tables, images, and multimodal content via LlamaIndex's managed parsing service; API usage, parse modes, and structured-output schemas"
+
+spec:
+  repository: "https://github.com/run-llama/llamaparse-agent-skills"
+  ref: "1f10f60a9eba0dbb490724c8104b0a865365f136"  # main as of 2026-03-03
+  path: "skills/llamaparse"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/run-llama/llamaparse-agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "run-llama/llamaparse-agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: LOW_ANALYZABILITY
+      reason: "The skill has only 2 files — SKILL.md and a single TypeScript example (`scripts/example.ts`). The scanner cannot analyze TypeScript source, giving the skill a 50% analyzability score. The `.ts` file is a documented, HF-sourced example snippet, not runtime-executed code."


### PR DESCRIPTION
Packages 2 skills from [`run-llama/llamaparse-agent-skills`](https://github.com/run-llama/llamaparse-agent-skills) (MIT), pinned to [`1f10f60`](https://github.com/run-llama/llamaparse-agent-skills/commit/1f10f60a9eba0dbb490724c8104b0a865365f136).

### Skills added
- `liteparse` — lightweight document parser (local)
- `llamaparse` — managed document-parsing service (LlamaIndex cloud)

### Security
- `liteparse`: no findings
- `llamaparse`: `LOW_ANALYZABILITY` allowlisted (single TS example file the scanner can't parse)

### Test plan
- [x] `task validate-skill` — VALID
- [x] `task scan-skill` passes after allowlist
- [ ] CI green
- [ ] 2 OCI artifacts published

Closes #496