### PR TITLE
feat(skills): package 6 ClickHouse skills

### DIFF
--- a/skills/chdb-datastore/spec.yaml
+++ b/skills/chdb-datastore/spec.yaml
@@ -1,0 +1,25 @@
+# ClickHouse chdb-datastore Skill
+# Use chDB as an in-process ClickHouse datastore.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/chdb-datastore:0.1.0
+
+metadata:
+  name: chdb-datastore
+  description: "Use chDB as an in-process ClickHouse datastore — embed the ClickHouse engine in Python, Go, Node.js, or Rust apps for local analytics, columnar storage, and fast aggregation without running a server"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/chdb-datastore"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: SECRET_CONNECTION_STRING
+      reason: "The skill's documentation contains an example `mysql://user:password@host:3306/dbname` connection-string shape illustrating how to connect chDB to external MySQL sources. The value is not a real credential — it's an illustrative string in markdown."

--- a/skills/chdb-sql/spec.yaml
+++ b/skills/chdb-sql/spec.yaml
@@ -1,0 +1,23 @@
+# ClickHouse chdb-sql Skill
+# Write SQL queries against chDB.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/chdb-sql:0.1.0
+
+metadata:
+  name: chdb-sql
+  description: "Write SQL queries against chDB — ClickHouse dialect syntax, aggregations, window functions, JSON handling, working with files (Parquet, CSV, JSON) directly from SQL, and common analytics patterns"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/chdb-sql"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/clickhouse-architecture-advisor/spec.yaml
+++ b/skills/clickhouse-architecture-advisor/spec.yaml
@@ -1,0 +1,23 @@
+# ClickHouse clickhouse-architecture-advisor Skill
+# Advise on ClickHouse architecture and deployment choices.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/clickhouse-architecture-advisor:0.1.0
+
+metadata:
+  name: clickhouse-architecture-advisor
+  description: "Advise on ClickHouse architecture — deployment topology (self-hosted vs Cloud), replication/sharding, storage tiers, materialized views, table engines (MergeTree family), and capacity planning"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/clickhouse-architecture-advisor"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/clickhouse-best-practices/spec.yaml
+++ b/skills/clickhouse-best-practices/spec.yaml
@@ -1,0 +1,23 @@
+# ClickHouse clickhouse-best-practices Skill
+# Best practices for schema, ingestion, and querying ClickHouse.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/clickhouse-best-practices:0.1.0
+
+metadata:
+  name: clickhouse-best-practices
+  description: "ClickHouse best practices across 34 rules — schema (sort keys, codecs, skipping indexes), ingestion, query patterns, agent connect/discover/plan/verify/execute workflow with MCP, CLI, and HTTP paths"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/clickhouse-best-practices"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/clickhousectl-cloud-deploy/spec.yaml
+++ b/skills/clickhousectl-cloud-deploy/spec.yaml
@@ -1,0 +1,25 @@
+# ClickHouse clickhousectl-cloud-deploy Skill
+# Deploy and manage ClickHouse Cloud with clickhousectl.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/clickhousectl-cloud-deploy:0.1.0
+
+metadata:
+  name: clickhousectl-cloud-deploy
+  description: "Deploy and manage ClickHouse Cloud with the clickhousectl CLI — authenticate, create services, manage credentials, connection strings, and common administrative workflows"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/clickhousectl-cloud-deploy"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official ClickHouse CLI installer `curl -fsSL https://clickhouse.com/cli | sh` as a documented install step. The destination is ClickHouse's own site."

--- a/skills/clickhousectl-local-dev/spec.yaml
+++ b/skills/clickhousectl-local-dev/spec.yaml
@@ -1,0 +1,25 @@
+# ClickHouse clickhousectl-local-dev Skill
+# Run and develop against ClickHouse locally.
+# Source: https://github.com/ClickHouse/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/clickhousectl-local-dev:0.1.0
+
+metadata:
+  name: clickhousectl-local-dev
+  description: "Run and develop against ClickHouse locally with clickhousectl — Docker-based local server, quick setup, schema/data bootstrap, and connection patterns for local-first development"
+
+spec:
+  repository: "https://github.com/ClickHouse/agent-skills"
+  ref: "d28416142e5634ce288602cd0c8f3457e68177ff"  # main as of 2026-04-20
+  path: "skills/clickhousectl-local-dev"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/ClickHouse/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "ClickHouse/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official ClickHouse CLI installer `curl -fsSL https://clickhouse.com/cli | sh` as a documented install step. The destination is ClickHouse's own site."


### PR DESCRIPTION
Packages 6 skills from [`ClickHouse/agent-skills`](https://github.com/ClickHouse/agent-skills) (Apache-2.0), pinned to [`d284161`](https://github.com/ClickHouse/agent-skills/commit/d28416142e5634ce288602cd0c8f3457e68177ff).

### Skills added
- `chdb-datastore` — in-process ClickHouse engine
- `chdb-sql` — SQL against chDB
- `clickhouse-architecture-advisor` — deployment/replication advice
- `clickhouse-best-practices` — 34 rules incl. agent workflow
- `clickhousectl-cloud-deploy` — ClickHouse Cloud management
- `clickhousectl-local-dev` — local Docker-based dev

MCP: `mcp-clickhouse` is packaged in toolhive catalog.

### Security allowlists
- `chdb-datastore`: `SECRET_CONNECTION_STRING` (illustrative MySQL connection string)
- `clickhousectl-*`: `PIPELINE_TAINT_FLOW` (`curl | sh` for official clickhouse.com/cli installer)

Closes #485