### PR TITLE
feat(skills): package 12 Firebase skills

### DIFF
--- a/skills/developing-genkit-dart/spec.yaml
+++ b/skills/developing-genkit-dart/spec.yaml
@@ -1,0 +1,25 @@
+# Firebase developing-genkit-dart Skill
+# Build AI features with Firebase Genkit in Dart/Flutter.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/developing-genkit-dart:0.1.0
+
+metadata:
+  name: developing-genkit-dart
+  description: "Build AI features with Firebase Genkit in Dart/Flutter — Genkit core concepts (flows, models, tools, indexing, prompts), plugin setup, and common AI workflows (RAG, agents) for Dart apps"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"  # main as of 2026-04-15
+  path: "skills/developing-genkit-dart"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official Genkit CLI installer `curl -sL cli.genkit.dev | bash` as a documented install command."

--- a/skills/developing-genkit-go/spec.yaml
+++ b/skills/developing-genkit-go/spec.yaml
@@ -1,0 +1,25 @@
+# Firebase developing-genkit-go Skill
+# Build AI features with Firebase Genkit in Go.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/developing-genkit-go:0.1.0
+
+metadata:
+  name: developing-genkit-go
+  description: "Build AI features with Firebase Genkit in Go — flows, models, tool calling, indexing and retrieval, observability, and deployment patterns for Go services"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/developing-genkit-go"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: PIPELINE_TAINT_FLOW
+      reason: "The skill's prerequisites cite the official Genkit CLI installer `curl -sL cli.genkit.dev | bash` as a documented install command."

--- a/skills/developing-genkit-js/spec.yaml
+++ b/skills/developing-genkit-js/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase developing-genkit-js Skill
+# Build AI features with Firebase Genkit in JavaScript/TypeScript.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/developing-genkit-js:0.1.0
+
+metadata:
+  name: developing-genkit-js
+  description: "Build AI features with Firebase Genkit in JavaScript/TypeScript — flows, models, tools, plugins, observability, and deployment patterns for Node.js and Next.js apps"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/developing-genkit-js"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-ai-logic-basics/spec.yaml
+++ b/skills/firebase-ai-logic-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-ai-logic-basics Skill
+# Use Firebase AI Logic to add AI features to mobile/web apps.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-ai-logic-basics:0.1.0
+
+metadata:
+  name: firebase-ai-logic-basics
+  description: "Use Firebase AI Logic — secure client-side access to Gemini and Imagen models from mobile/web apps with App Check, prompt and schema management, and per-user rate controls"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-ai-logic-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-app-hosting-basics/spec.yaml
+++ b/skills/firebase-app-hosting-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-app-hosting-basics Skill
+# Deploy full-stack web apps with Firebase App Hosting.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-app-hosting-basics:0.1.0
+
+metadata:
+  name: firebase-app-hosting-basics
+  description: "Deploy full-stack web apps with Firebase App Hosting — Next.js and Angular framework support, GitHub integration, rollouts, backends, and environment configuration"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-app-hosting-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-auth-basics/spec.yaml
+++ b/skills/firebase-auth-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-auth-basics Skill
+# Add authentication with Firebase Authentication.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-auth-basics:0.1.0
+
+metadata:
+  name: firebase-auth-basics
+  description: "Add authentication with Firebase Authentication — sign-in methods (email/password, phone, OAuth providers, anonymous), session management, custom claims, and integration patterns across platforms"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-auth-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-basics/spec.yaml
+++ b/skills/firebase-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-basics Skill
+# Firebase fundamentals — project setup, SDK install, CLI.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-basics:0.1.0
+
+metadata:
+  name: firebase-basics
+  description: "Firebase fundamentals — project setup, SDK install across platforms, Firebase CLI, local emulators, environment config, and common product selection guidance"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-data-connect-basics/spec.yaml
+++ b/skills/firebase-data-connect-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-data-connect-basics Skill
+# Firebase SQL Connect (formerly Data Connect) — managed Postgres + GraphQL.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-data-connect-basics:0.1.0
+
+metadata:
+  name: firebase-data-connect-basics
+  description: "Firebase SQL Connect (formerly Data Connect) — managed Postgres with auto-generated GraphQL APIs, typed client SDKs, and Firebase Auth integration"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-data-connect-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-firestore-enterprise-native-mode/spec.yaml
+++ b/skills/firebase-firestore-enterprise-native-mode/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-firestore-enterprise-native-mode Skill
+# Firestore in Datastore Enterprise / Native Mode for Google Cloud.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-firestore-enterprise-native-mode:0.1.0
+
+metadata:
+  name: firebase-firestore-enterprise-native-mode
+  description: "Firestore in Enterprise Native Mode for Google Cloud — backend-only operations, advanced transaction semantics, multi-region replication, and migration guidance"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-firestore-enterprise-native-mode"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-firestore-standard/spec.yaml
+++ b/skills/firebase-firestore-standard/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-firestore-standard Skill
+# Firestore Standard — document database for mobile/web apps.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-firestore-standard:0.1.0
+
+metadata:
+  name: firebase-firestore-standard
+  description: "Firestore Standard — document database for mobile/web apps with offline support, realtime sync, security rules, indexes, and data modeling patterns"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-firestore-standard"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-hosting-basics/spec.yaml
+++ b/skills/firebase-hosting-basics/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-hosting-basics Skill
+# Firebase Hosting — static and dynamic site hosting.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-hosting-basics:0.1.0
+
+metadata:
+  name: firebase-hosting-basics
+  description: "Firebase Hosting — static and dynamic site hosting with global CDN; rewrite/redirect rules, preview channels, GitHub Actions integration, and custom domains"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-hosting-basics"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/firebase-security-rules-auditor/spec.yaml
+++ b/skills/firebase-security-rules-auditor/spec.yaml
@@ -1,0 +1,23 @@
+# Firebase firebase-security-rules-auditor Skill
+# Audit Firebase Security Rules for Firestore, Realtime Database, Cloud Storage.
+# Source: https://github.com/firebase/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/firebase-security-rules-auditor:0.1.0
+
+metadata:
+  name: firebase-security-rules-auditor
+  description: "Audit Firebase Security Rules for Firestore, Realtime Database, and Cloud Storage — common bypass patterns, authorization gaps, path-traversal issues, and rule-test recommendations"
+
+spec:
+  repository: "https://github.com/firebase/agent-skills"
+  ref: "4679fc8dd31f77f068301eb4796ec37904da53aa"
+  path: "skills/firebase-security-rules-auditor"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/firebase/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "firebase/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 12 skills from [`firebase/agent-skills`](https://github.com/firebase/agent-skills) (Apache-2.0), pinned to [`4679fc8`](https://github.com/firebase/agent-skills/commit/4679fc8dd31f77f068301eb4796ec37904da53aa).

### Skills added

**Genkit AI framework**
- `developing-genkit-dart` / `developing-genkit-go` / `developing-genkit-js`

**Firebase products**
- `firebase-basics` / `firebase-ai-logic-basics` / `firebase-auth-basics`
- `firebase-hosting-basics` / `firebase-app-hosting-basics`
- `firebase-data-connect-basics` (Firebase SQL Connect)
- `firebase-firestore-standard` / `firebase-firestore-enterprise-native-mode`
- `firebase-security-rules-auditor`

### Security allowlists
- `developing-genkit-dart` / `-go`: `PIPELINE_TAINT_FLOW` for documented `cli.genkit.dev | bash` installer
- All: `MANIFEST_MISSING_LICENSE` (INFO)

Closes #484