### PR TITLE
feat(skills): package 8 Pulumi skills

### DIFF
--- a/skills/package-usage/spec.yaml
+++ b/skills/package-usage/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi package-usage Skill
+# Audit Pulumi package usage across stacks.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/package-usage:0.1.0
+
+metadata:
+  name: package-usage
+  description: "Audit Pulumi package usage across stacks — cross-stack inventory of provider/component packages, detect unused or outdated dependencies (hand off to provider-upgrade for version bumps)"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/package-usage"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/provider-upgrade/spec.yaml
+++ b/skills/provider-upgrade/spec.yaml
@@ -1,0 +1,25 @@
+# Pulumi provider-upgrade Skill
+# Upgrade Pulumi provider versions safely across stacks.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/provider-upgrade:0.1.0
+
+metadata:
+  name: provider-upgrade
+  description: "Upgrade Pulumi provider packages safely — npm/pip/go package bumps, post-upgrade resource-breakage diagnosis, cross-stack upgrade planning"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/provider-upgrade"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: COMPOUND_EXTRACT_EXECUTE
+      reason: "The skill documents standard `npm install` / `pip install` / `go get` upgrade workflows which involve extracting packaged archives and running their lifecycle scripts. The scanner itself notes 'found in documentation — may be instructional'."

--- a/skills/pulumi-automation-api/spec.yaml
+++ b/skills/pulumi-automation-api/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi pulumi-automation-api Skill
+# Drive Pulumi programmatically with the Automation API.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pulumi-automation-api:0.1.0
+
+metadata:
+  name: pulumi-automation-api
+  description: "Drive Pulumi programmatically with the Automation API — embed up/destroy/preview operations, manage stacks from code (TypeScript, Python, Go, .NET), event streaming, and workspace configuration"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/pulumi-automation-api"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pulumi-best-practices/spec.yaml
+++ b/skills/pulumi-best-practices/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi pulumi-best-practices Skill
+# General Pulumi best practices for IaC projects.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pulumi-best-practices:0.1.0
+
+metadata:
+  name: pulumi-best-practices
+  description: "Pulumi best practices across IaC projects — project and stack organization, config/secret management, resource naming, output handling, provider selection, and common anti-patterns"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/pulumi-best-practices"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pulumi-component/spec.yaml
+++ b/skills/pulumi-component/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi pulumi-component Skill
+# Build reusable Pulumi Components.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pulumi-component:0.1.0
+
+metadata:
+  name: pulumi-component
+  description: "Build reusable Pulumi Components — author multi-language components via ComponentResource, package for Pulumi Registry, handle inputs/outputs, schema, and versioning"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/pulumi-component"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pulumi-esc/spec.yaml
+++ b/skills/pulumi-esc/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi pulumi-esc Skill
+# Pulumi Environments, Secrets, and Configurations.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pulumi-esc:0.1.0
+
+metadata:
+  name: pulumi-esc
+  description: "Pulumi ESC (Environments, Secrets, Configurations) — centralize and share config/secrets across stacks, integrate with CI/CD, resolve at runtime from cloud providers or static sources"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"  # main as of 2026-04-16
+  path: "authoring/skills/pulumi-esc"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/pulumi-upgrade-provider/spec.yaml
+++ b/skills/pulumi-upgrade-provider/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi pulumi-upgrade-provider Skill
+# Upgrade a Pulumi bridged provider to a new upstream version.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/pulumi-upgrade-provider:0.1.0
+
+metadata:
+  name: pulumi-upgrade-provider
+  description: "Upgrade a Pulumi bridged provider to a new upstream Terraform-provider version — pulumi-terraform-bridge integration, schema diffing, generated SDK regeneration, and release checklist"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/pulumi-upgrade-provider"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/upstream-patches/spec.yaml
+++ b/skills/upstream-patches/spec.yaml
@@ -1,0 +1,23 @@
+# Pulumi upstream-patches Skill
+# Manage upstream patches for bridged Pulumi providers.
+# Source: https://github.com/pulumi/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/upstream-patches:0.1.0
+
+metadata:
+  name: upstream-patches
+  description: "Manage upstream patches for bridged Pulumi providers — apply, refresh, and rebase patches against upstream Terraform providers; common workflows for provider maintainers"
+
+spec:
+  repository: "https://github.com/pulumi/agent-skills"
+  ref: "fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+  path: "authoring/skills/upstream-patches"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/pulumi/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "pulumi/agent-skills is licensed Apache-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 8 skills from [`pulumi/agent-skills`](https://github.com/pulumi/agent-skills) (Apache-2.0), pinned to [`fbeac07`](https://github.com/pulumi/agent-skills/commit/fbeac07327a601b954ba82e7f7e1c24cf3b1fa71).

### Skills added
- `pulumi-esc` — Environments, Secrets, Configurations
- `package-usage` — cross-stack package inventory
- `provider-upgrade` — safe provider version bumps
- `pulumi-automation-api` — programmatic Pulumi
- `pulumi-best-practices` — IaC patterns
- `pulumi-component` — reusable ComponentResource authoring
- `pulumi-upgrade-provider` — bridge provider upgrades
- `upstream-patches` — patch workflows

### Security
`provider-upgrade` allowlists `COMPOUND_EXTRACT_EXECUTE` (documented npm/pip/go install patterns).

Closes #487