### PR TITLE
feat(skills): package 9 Datadog skills

### DIFF
--- a/skills/dd-apm/spec.yaml
+++ b/skills/dd-apm/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-apm Skill
+# Datadog APM — traces, services, performance analysis via the pup CLI.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-apm:0.1.0
+
+metadata:
+  name: dd-apm
+  description: "Datadog APM via the `pup` CLI — search traces, inspect services, surface slow endpoints and error patterns; analyze latency/throughput and trace-to-log correlation"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"  # main as of 2026-04-15
+  path: "dd-apm"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-docs/spec.yaml
+++ b/skills/dd-docs/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-docs Skill
+# Search Datadog documentation via the pup CLI.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-docs:0.1.0
+
+metadata:
+  name: dd-docs
+  description: "Search Datadog documentation via the `pup` CLI — look up product docs, integrations, and API references for grounding Datadog-related agent work"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-docs"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-llmo-eval-bootstrap/spec.yaml
+++ b/skills/dd-llmo-eval-bootstrap/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-llmo eval-bootstrap Skill
+# Bootstrap LLM evaluation sessions in Datadog LLM Observability.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-llmo-eval-bootstrap:0.1.0
+
+metadata:
+  name: dd-llmo-eval-bootstrap
+  description: "Bootstrap LLM evaluation sessions in Datadog LLM Observability — set up datasets, metrics, and baseline comparisons for prompt or model changes"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"  # main as of 2026-04-15
+  path: "dd-llmo/eval-bootstrap"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-llmo-eval-session-classify/spec.yaml
+++ b/skills/dd-llmo-eval-session-classify/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-llmo eval-session-classify Skill
+# Classify LLM evaluation sessions.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-llmo-eval-session-classify:0.1.0
+
+metadata:
+  name: dd-llmo-eval-session-classify
+  description: "Classify LLM evaluation sessions in Datadog LLM Observability — group sessions by outcome, taxonomy, or failure mode for regression detection and reporting"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-llmo/eval-session-classify"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-llmo-eval-trace-rca/spec.yaml
+++ b/skills/dd-llmo-eval-trace-rca/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-llmo eval-trace-rca Skill
+# Root-cause analysis over LLM evaluation traces.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-llmo-eval-trace-rca:0.1.0
+
+metadata:
+  name: dd-llmo-eval-trace-rca
+  description: "Root-cause analysis over LLM evaluation traces in Datadog LLM Observability — drill into failed spans, identify common failure patterns, and produce actionable findings"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-llmo/eval-trace-rca"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-llmo-experiment-analyzer/spec.yaml
+++ b/skills/dd-llmo-experiment-analyzer/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-llmo experiment-analyzer Skill
+# Analyze LLM experiments in Datadog LLM Observability.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-llmo-experiment-analyzer:0.1.0
+
+metadata:
+  name: dd-llmo-experiment-analyzer
+  description: "Analyze LLM experiments in Datadog LLM Observability — compare variants, surface metric deltas, and recommend promotion/rollback based on evaluation results"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-llmo/experiment-analyzer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-logs/spec.yaml
+++ b/skills/dd-logs/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-logs Skill
+# Search Datadog logs, manage pipelines and archives via the pup CLI.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-logs:0.1.0
+
+metadata:
+  name: dd-logs
+  description: "Search Datadog logs and manage pipelines and archives via the `pup` CLI — query syntax, time-range filtering, facets/tags, and log-to-metric or log-to-trace correlation"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-logs"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-monitors/spec.yaml
+++ b/skills/dd-monitors/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-monitors Skill
+# Create, manage, and mute Datadog monitors via the pup CLI.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-monitors:0.1.0
+
+metadata:
+  name: dd-monitors
+  description: "Create, manage, and mute Datadog monitors and alerts via the `pup` CLI — monitor types, query syntax, thresholds, downtimes, and alert-routing configuration"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-monitors"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/dd-pup/spec.yaml
+++ b/skills/dd-pup/spec.yaml
@@ -1,0 +1,23 @@
+# Datadog dd-pup Skill
+# Primary pup CLI — auth, PATH setup, all pup commands.
+# Source: https://github.com/datadog-labs/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/dd-pup:0.1.0
+
+metadata:
+  name: dd-pup
+  description: "Primary `pup` CLI for Datadog agent workflows — authentication, PATH setup, command reference across monitors, logs, APM, metrics, and docs"
+
+spec:
+  repository: "https://github.com/datadog-labs/agent-skills"
+  ref: "a04611e9d3c402859f7d973be451c16cd5982ca5"
+  path: "dd-pup"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/datadog-labs/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "datadog-labs/agent-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
Packages 9 skills from [`datadog-labs/agent-skills`](https://github.com/datadog-labs/agent-skills) (MIT), pinned to [`a04611e`](https://github.com/datadog-labs/agent-skills/commit/a04611e9d3c402859f7d973be451c16cd5982ca5).

### Skills added

**Core pup CLI**
- `dd-pup` — primary CLI (auth, PATH, commands)
- `dd-apm`, `dd-docs`, `dd-logs`, `dd-monitors`

**LLM Observability (`dd-llmo/*`)**
- `dd-llmo-eval-bootstrap`
- `dd-llmo-eval-session-classify`
- `dd-llmo-eval-trace-rca`
- `dd-llmo-experiment-analyzer`

Each of these lives at `dd-llmo/<sub>` in the upstream repo; packaged here as separate top-level dockyard skills named `dd-llmo-<sub>`.

### Vendor affiliation

The `datadog-labs` org is Datadog-affiliated (commits come from `@datadoghq.com` email addresses). Registry criteria considers this an official-vendor reference; reviewers may wish to confirm org → vendor link before merging.

### Security
All 9 carry only `MANIFEST_MISSING_LICENSE` (INFO).

Closes #490