### PR TITLE
fix(ci): surface dockhand errors in Build Skill Artifacts step

### DIFF
--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -333,6 +333,12 @@ jobs:
           IMAGE_REF: ${{ steps.meta.outputs.image_name }}:${{ steps.meta.outputs.version }}
           PUSH: ${{ github.event_name != 'pull_request' }}
         run: |
+          # pipefail so a dockhand failure propagates through `tee` and fails
+          # the step. The previous `output=$(dockhand ... 2>&1); echo "$output"`
+          # pattern combined with `set -e` exited before echoing, hiding the
+          # real error from the job log.
+          set -o pipefail
+
           echo "Building skill artifact for $CONFIG_FILE"
 
           build_args="--config $CONFIG_FILE --tag $IMAGE_REF"
@@ -340,12 +346,15 @@ jobs:
             build_args="$build_args --push"
           fi
 
-          output=$(/tmp/dockhand build-skill $build_args 2>&1)
-          echo "$output"
+          log_file=$(mktemp)
+          /tmp/dockhand build-skill $build_args 2>&1 | tee "$log_file"
 
-          # Extract digest from output
-          digest=$(echo "$output" | grep "^Digest:" | awk '{print $2}')
+          # Extract digest from captured output. `|| true` so an absent
+          # "Digest:" line yields digest="" without failing the step; downstream
+          # steps already gate on `steps.build.outputs.digest != ''`.
+          digest=$(grep "^Digest:" "$log_file" | awk '{print $2}' || true)
           echo "digest=$digest" >> $GITHUB_OUTPUT
+          rm -f "$log_file"
 
       - name: Sign skill artifact with Cosign
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- The `Build skill artifact` step in `.github/workflows/build-skills.yml` captured dockhand's combined output with `output=\$(/tmp/dockhand build-skill ... 2>&1)` and then `echo \"\$output\"`. Under `set -e`, a dockhand failure exits the shell on the assignment line before `echo` runs, so the only signal in the job log is `##[error]Process completed with exit code 1.` — the actual dockhand error is never printed.
- This is exactly why we could not diagnose the post-merge failures on #502 and #506 (some matrix cells fail, others succeed; logs are silent either way).
- Stream dockhand output through `tee` to a tempfile and enable `pipefail`, so output is visible in real time *and* a non-zero exit still fails the step.

## Behavior
- Success path: unchanged — digest is extracted from the captured log and written to `steps.build.outputs.digest`.
- Failure path: dockhand's stdout/stderr now appears in the job log, then pipefail + errexit fails the step.
- Empty-digest path preserved via `|| true` on the `grep | awk` pipeline; downstream steps already gate on `digest != ''`.

## Test plan
- [ ] Workflow YAML parses (validated locally).
- [ ] Merge, then re-run `Build Skill Artifacts` via `workflow_dispatch` (or retrigger the failed runs for #502 / #506) and confirm dockhand error text is visible in the job log.
- [ ] Confirm successful builds still write `steps.build.outputs.digest` and proceed through Cosign + attestation steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)