### PR TITLE
fix(ci): retry dockhand build-skill on transient GHCR 5xx

### DIFF
--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -334,9 +334,8 @@ jobs:
           PUSH: ${{ github.event_name != 'pull_request' }}
         run: |
           # pipefail so a dockhand failure propagates through `tee` and fails
-          # the step. The previous `output=$(dockhand ... 2>&1); echo "$output"`
-          # pattern combined with `set -e` exited before echoing, hiding the
-          # real error from the job log.
+          # the step. Without it, `set -e` alone would not fail on a non-zero
+          # left-hand side of the pipeline.
           set -o pipefail
 
           echo "Building skill artifact for $CONFIG_FILE"
@@ -347,7 +346,28 @@ jobs:
           fi
 
           log_file=$(mktemp)
-          /tmp/dockhand build-skill $build_args 2>&1 | tee "$log_file"
+
+          # Retry dockhand on non-zero exit. Matrix jobs concurrently pushing
+          # brand-new GHCR packages regularly hit transient 5xx from the
+          # registry (observed "500 unknown: unknown error" on manifest PUT).
+          # A linear backoff is enough — a successful retry typically lands
+          # within the first extra attempt.
+          max_attempts=3
+          attempt=1
+          while :; do
+            echo "=== dockhand build-skill attempt ${attempt}/${max_attempts} ==="
+            if /tmp/dockhand build-skill $build_args 2>&1 | tee "$log_file"; then
+              break
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "dockhand build-skill failed after ${attempt} attempt(s)" >&2
+              exit 1
+            fi
+            backoff=$(( 10 * attempt ))
+            echo "dockhand build-skill failed; retrying in ${backoff}s..." >&2
+            sleep "$backoff"
+            attempt=$(( attempt + 1 ))
+          done
 
           # Extract digest from captured output. `|| true` so an absent
           # "Digest:" line yields digest="" without failing the step; downstream


### PR DESCRIPTION
## Summary
Concurrent first-time pushes to brand-new GHCR packages regularly fail with `response status code 500: unknown: unknown error` on the manifest PUT. We observed this clearly once PR #516 unmasked the dockhand error:

- #511 (LlamaIndex, 2 skills): 1 failed.
- #498 (Sentry, 18 skills): 16/17 failed — rate scales with matrix width.
- #502, #506 (Gemini, Neon): same class of failure, retried successfully from `workflow_dispatch` once the package shells existed.

Wrap the `dockhand build-skill` invocation in a bounded retry loop (3 attempts, 10s then 20s backoff). A successful retry typically lands on the first extra attempt, and matrix jobs have a 30-minute timeout — worst-case added latency is well under budget. Genuine build/validation errors still fail; they just cost \~30s before surfacing.

## Behavior
- Each attempt's dockhand output streams through `tee` to the job log (same visibility as PR #516).
- Only the last attempt's output is kept in the tempfile used for digest extraction — that's the successful one on exit, so digest extraction is unchanged.
- If all 3 attempts fail, the step exits 1 with all attempts visible in the job log.
- Empty-digest path preserved via `|| true`; downstream steps already gate on `digest != ''`.

## Test plan
- [ ] Workflow YAML parses (validated locally).
- [ ] Merge and watch the next skills batch (\~10+ specs) push cleanly.
- [ ] If a 500 occurs on an individual attempt, confirm the retry succeeds and the step ends green.
- [ ] Retry the LlamaIndex #511 and Sentry #498 runs (already triggered manually); after this PR lands, those should not need manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)