### PR TITLE
ci: raise grype severity cutoff from medium to high

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -539,7 +539,7 @@ jobs:
         uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
         with:
           image: "local-scan:${{ steps.meta.outputs.server_name }}-${{ steps.meta.outputs.version }}"
-          severity-cutoff: "medium"
+          severity-cutoff: "high"
           output-format: "sarif"
 
       - name: Upload Grype results to GitHub Security


### PR DESCRIPTION
## Summary
- Bump the grype `severity-cutoff` in `build-containers.yml` from `medium` to `high`, so only high/critical CVEs fail the build.
- Medium and below still run and upload to the GitHub Security tab via SARIF — they're visible, just non-blocking.

## Why
Medium-severity findings in base images and transitive npm/pip deps regularly block otherwise-healthy container builds (e.g. PR #509 packaging the Pinecone MCP), often with no upstream fix available. High/critical is a more actionable gate.

## Test plan
- [ ] CI passes on this PR
- [ ] Re-run PR #509 (or a rebase) and confirm the `build-containers` job no longer fails the grype step on medium findings
- [ ] Confirm medium/low vulns still show up in the Security tab for the affected images

🤖 Generated with [Claude Code](https://claude.com/claude-code)