### PR TITLE
ci: set only-fixed on grype scan to skip unfixable CVEs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -540,6 +540,7 @@ jobs:
         with:
           image: "local-scan:${{ steps.meta.outputs.server_name }}-${{ steps.meta.outputs.version }}"
           severity-cutoff: "high"
+          only-fixed: "true"
           output-format: "sarif"
 
       - name: Upload Grype results to GitHub Security


### PR DESCRIPTION
## Summary

- Adds `only-fixed: true` to the grype scan step in `build-containers.yml`.
- Makes the HIGH+ severity gate ignore CVEs that have no available fix, so spec.yaml PRs aren't blocked by base-image drift the author cannot resolve.

## Why

PR #509 (Pinecone MCP) is currently blocked by three HIGH findings in the generated image:

| CVE | Package | Fix |
|---|---|---|
| CVE-2026-32631 | `git` (apk) | no Alpine fix yet |
| CVE-2026-27135 | `nghttp2-libs` (apk) | no fix yet |
| GHSA-c2c7-rcm5-vvqj | `picomatch` (bundled in npm) | 4.0.4 |

Two of the three have no remediation available, so failing the build on them offers no path to green other than waiting for an upstream patch. With `only-fixed: true`, grype still fails when a fix exists (picomatch above would still block until the base image bumps npm) but stops failing on CVEs we can't act on.

The base-image bump is still the right long-term fix; this change just keeps the gate actionable in the meantime.

## Test plan

- [ ] CI `build-containers` passes on this PR (no spec.yaml changed, so the grype matrix will skip — sanity-check by landing a subsequent no-op spec change or by rebasing PR #509 on this)
- [ ] After merge, PR #509's `build-containers (npx/pinecone-mcp/spec.yaml)` should either go green (if picomatch has flowed through) or fail only on the picomatch fix, not the two apk CVEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)