### PR TITLE
chore(ci): add Grype ignore rules for unreachable base-image findings

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,67 @@
+# Grype vulnerability ignore rules for dockyard.
+#
+# Philosophy
+# ----------
+# These rules suppress Grype findings that are NOT a security risk for the
+# running MCP server, so PR authors are not blocked on vulnerabilities they
+# cannot fix. A finding qualifies for suppression here if it is EITHER:
+#
+#   1. In a base-image layer we do not control, where the fix path is an
+#      upstream base-image rebuild (OS packages, bundled language runtimes).
+#   2. In code that is not reachable from the MCP server's runtime attack
+#      surface (e.g. the system-bundled `npm` CLI, which is invoked only at
+#      image build time to install the server package).
+#
+# Runtime dependencies of a specific MCP server (under `/app/node_modules`
+# or `/opt/uv-tools`) are intentionally NOT ignored here: those reflect
+# real risks in the upstream server package and should be resolved by that
+# package bumping its vulnerable dep, or by per-finding analysis in a
+# follow-up PR.
+#
+# Revisit on every toolhive / base-image bump; most entries should roll off
+# as upstream Node, Python, Debian and Alpine images pick up fixes.
+
+ignore:
+  # ── Base image: Debian OS packages ──────────────────────────────────────
+  # CVEs in `.deb` packages shipped by the upstream Debian-based base image
+  # (e.g. the `python:3.x` image used by uvx servers). Debian security tracks
+  # these independently; the fix path is a base-image rebuild with patched
+  # Debian packages. The dockyard Dockerfiles never `apt-get install` their
+  # own packages, so any `.deb` finding is by construction a base-image one.
+  - package:
+      type: deb
+
+  # ── Base image: Alpine OS packages ──────────────────────────────────────
+  # CVEs in `.apk` packages shipped by the Alpine-based base image
+  # (e.g. `node:22-alpine` used by npx servers). Alpine security tracks
+  # these independently; fix path is a base-image rebuild. The dockyard
+  # Dockerfiles never `apk add` their own packages.
+  - package:
+      type: apk
+
+  # ── Base image: system-bundled npm CLI ──────────────────────────────────
+  # The `npm` CLI shipped inside the Node base image lives under
+  # `/usr/local/lib/node_modules/npm/` and is used only at image build time
+  # to install the MCP server package. It is not invoked by the running MCP
+  # server, so CVEs in its transitive deps (picomatch via tinyglobby,
+  # minimatch, glob, tar, cacache, node-gyp, ...) are not reachable from
+  # the server's runtime attack surface. Fix path: upstream Node image
+  # rebuild with a newer bundled npm.
+  - package:
+      location: "/usr/local/lib/node_modules/npm/**"
+
+  # ── Base image: Python interpreter ──────────────────────────────────────
+  # CVEs in the CPython binary shipped by the base image. Fixed by a
+  # base-image rebuild pointing at a patched Python tag (tracked by
+  # toolhive). The upstream python:3.x images are rebuilt whenever CPython
+  # ships a security release, so these entries should roll off after the
+  # next toolhive bump.
+  - package:
+      location: "/usr/local/bin/python*"
+
+  # ── Base image: Node.js runtime ─────────────────────────────────────────
+  # CVEs in the `node` binary itself, shipped by the base image. Same
+  # treatment as Python above: fixed by upstream base-image rebuild and
+  # picked up via toolhive bumps.
+  - package:
+      location: "/usr/local/bin/node"


### PR DESCRIPTION
## Summary

Adds a `.grype.yaml` at repo root that suppresses Grype findings the PR author has no lever to fix: base-image OS packages, the bundled `npm` CLI (build-time only), and the base-image Python/Node runtimes. Runtime deps of specific MCP servers (`/app/node_modules/…` and `/opt/uv-tools/…`) are intentionally left visible.

Every currently open PR is failing `build-containers / Run Grype vulnerability scanner` because Grype's DB updated 2026-04-21 with new high/critical fixes for packages that ship inside our base images. The scanner is configured with `severity-cutoff: high`, `only-fixed: true`, `fail-build: true`, so any newly-fixed high/critical in the base image turns every PR red. This change unblocks PRs whose only failure is in the base image, while keeping real server-dep issues blocking as before.

## What each rule covers and why

| Rule | Rationale |
|---|---|
| `package.type: deb` | Debian OS packages in the base image (`python:3.x`). Dockyard Dockerfiles never `apt-get install` anything of their own. Fix path: base-image rebuild tracked by upstream Debian. |
| `package.type: apk` | Alpine OS packages in the base image (`node:22-alpine` / `node:24-alpine`). Dockyard Dockerfiles never `apk add`. Fix path: base-image rebuild tracked by upstream Alpine. |
| `package.location: /usr/local/lib/node_modules/npm/**` | The system-bundled `npm` CLI runs only at image build time (to `npm install` the MCP server). It is not invoked by the running server, so CVEs in its internal deps — picomatch via tinyglobby, minimatch, glob, tar, cacache, node-gyp — are not reachable from the server's runtime attack surface. |
| `package.location: /usr/local/bin/python*` | CVEs in the CPython binary from the base image. Fixed by a base-image rebuild. |
| `package.location: /usr/local/bin/node` | CVEs in the Node.js runtime binary from the base image. Fixed by a base-image rebuild. |

Full per-rule comments live inline in the file.

## What this PR does NOT ignore

These stay blocking and need the upstream MCP server package (or the upstream Go module) to bump vulnerable deps:

- `/app/node_modules/…` findings: `next`, `protobufjs`, `axios`, `lodash`, `basic-ftp`, `undici`, `path-to-regexp`, `@modelcontextprotocol/sdk`, `fast-xml-parser`, `oauth2-server`, `convict`, application-level `picomatch`, ...
- `/opt/uv-tools/<server>/…` findings: `fastmcp`, `mcp` (Python SDK), `aiohttp`, `pyjwt`, `pillow`, `lupa`, `langchain-core`, ...
- `/app/mcp-server` Go stdlib CVEs (the `netbird` MCP binary) — these reroll when toolhive bumps the Go toolchain.

## Expected impact on open PRs

Should unblock:
- `octocode-mcp` bumps (#534, #475) — only fails on picomatch in the system npm tree
- `chrome-devtools-mcp` (#525)
- `playwright-mcp` (#472)

Will still fail until upstream fixes:
- all npx PRs whose server has vulnerable deps under `/app/node_modules/…`
- all uvx PRs whose server has vulnerable deps under `/opt/uv-tools/…`

## Validation

Built three images locally with `dockhand`, scanned with `anchore/grype` and the new `-c .grype.yaml`:

- `local-scan:octocode-test` — 3 findings before (picomatch GHSA-c2c7-rcm5-vvqj high + 2 mediums), **0 after**.
- `local-scan:aws-doc-test` — python stdlib + debian libs before, **0 after**.
- `local-scan:chroma-test` — still fails on 3 high `mcp` 1.6.0 GHSAs in `/opt/uv-tools/chroma-mcp/`, as intended (real runtime-dep risk, not a base-image one).

## Test plan

- [ ] `Build MCP Server Containers` CI on this PR passes (no spec changes, so only a lint-level validation that the config doesn't break the workflow).
- [ ] After merge, rebase one each of: (a) `renovate/octocode-mcp-14.x` — expected to go green; (b) `renovate/mcp-clickhouse-0.x` — expected to still fail on `fastmcp`, confirming scope is narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)