### PR TITLE
fix(scan): block only on HIGH/CRITICAL findings by default

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -261,6 +261,10 @@ jobs:
           MCP_SCANNER_ENABLE_LLM: ${{ vars.MCP_SCANNER_ENABLE_LLM || 'false' }}
           MCP_SCANNER_LLM_API_KEY: ${{ secrets.MCP_SCANNER_LLM_API_KEY }}
           MCP_SCANNER_LLM_MODEL: ${{ vars.MCP_SCANNER_LLM_MODEL || '' }}
+          # Severity threshold for blocking. Findings below this severity are
+          # surfaced as warnings but do not fail the job. One of: INFO, LOW,
+          # MEDIUM, HIGH, CRITICAL. Tune via PR.
+          MCP_SCANNER_BLOCK_SEVERITY: HIGH
           SERVER_NAME: ${{ steps.meta.outputs.server_name }}
           PROTOCOL: ${{ steps.meta.outputs.protocol }}
           CONFIG_FILE: ${{ matrix.config }}

--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -228,6 +228,10 @@ jobs:
           SKILL_SCANNER_LLM_MODEL: ${{ vars.SKILL_SCANNER_LLM_MODEL }}
           # Optional consensus voting — N>1 multiplies LLM cost per scan.
           SKILL_SCANNER_LLM_CONSENSUS_RUNS: ${{ vars.SKILL_SCANNER_LLM_CONSENSUS_RUNS }}
+          # Severity threshold for blocking. Findings below this severity are
+          # surfaced as warnings but do not fail the job. One of: INFO, LOW,
+          # MEDIUM, HIGH, CRITICAL. Tune via PR.
+          SKILL_SCANNER_BLOCK_SEVERITY: HIGH
           SKILL_NAME: ${{ steps.meta.outputs.skill_name }}
           SOURCE_DIR: ${{ steps.skill-src.outputs.source_dir }}
           CONFIG_FILE: ${{ matrix.config }}

--- a/scripts/mcp-scan/process_scan_results.py
+++ b/scripts/mcp-scan/process_scan_results.py
@@ -13,6 +13,24 @@ import os
 # Global config file location (relative to this script)
 GLOBAL_CONFIG_FILE = os.path.join(os.path.dirname(__file__), 'global_allowed_issues.yaml')
 
+# Higher rank = more severe. Unknown severities are treated as blocking so an
+# unrecognized value never silently slips past the gate.
+SEVERITY_RANK = {"INFO": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+DEFAULT_BLOCK_SEVERITY = "HIGH"
+
+
+def _block_severity_threshold():
+    raw = os.environ.get("MCP_SCANNER_BLOCK_SEVERITY", DEFAULT_BLOCK_SEVERITY)
+    rank = SEVERITY_RANK.get((raw or "").strip().upper())
+    return rank if rank is not None else SEVERITY_RANK[DEFAULT_BLOCK_SEVERITY]
+
+
+def _is_blocking_severity(severity, threshold):
+    rank = SEVERITY_RANK.get((severity or "").strip().upper())
+    if rank is None:
+        return True
+    return rank >= threshold
+
 
 def load_global_allowed_issues():
     """
@@ -147,12 +165,14 @@ def process_cisco_scan_results(scan_data, allowed_issues):
     }
 
     Returns:
-        Tuple of (tools_scanned, blocking_issues, allowed_issues_found, analyzers)
+        Tuple of (tools_scanned, blocking_issues, warning_issues, allowed_issues_found, analyzers)
     """
     tools_scanned = 0
     blocking_issues = []
+    warning_issues = []
     allowed_issues_found = []
     analyzers = []
+    threshold = _block_severity_threshold()
 
     # Handle different possible data structures
     if isinstance(scan_data, list):
@@ -222,10 +242,12 @@ def process_cisco_scan_results(scan_data, allowed_issues):
                 if is_allowed:
                     issue_detail['allowed_reason'] = reason
                     allowed_issues_found.append(issue_detail)
-                else:
+                elif _is_blocking_severity(severity, threshold):
                     blocking_issues.append(issue_detail)
+                else:
+                    warning_issues.append(issue_detail)
 
-    return tools_scanned, blocking_issues, allowed_issues_found, analyzers
+    return tools_scanned, blocking_issues, warning_issues, allowed_issues_found, analyzers
 
 
 def main():
@@ -302,9 +324,42 @@ def main():
             scan_data = json.loads(json_content)
 
         # Process Cisco scanner results
-        tools_scanned, blocking_issues, allowed_issues_found, analyzers = process_cisco_scan_results(
-            scan_data, allowed_issues
-        )
+        (
+            tools_scanned,
+            blocking_issues,
+            warning_issues,
+            allowed_issues_found,
+            analyzers,
+        ) = process_cisco_scan_results(scan_data, allowed_issues)
+
+        threshold_name = os.environ.get(
+            "MCP_SCANNER_BLOCK_SEVERITY", DEFAULT_BLOCK_SEVERITY
+        ).upper()
+
+        def _print_warning_issues():
+            if not warning_issues:
+                return
+            print(
+                f"ℹ️  Below-threshold findings (block threshold = {threshold_name}, not blocking):",
+                file=sys.stderr,
+            )
+            for issue in warning_issues:
+                print(
+                    f"  - [{issue['code']}] ({issue.get('severity')}) {issue['message']}",
+                    file=sys.stderr,
+                )
+                if issue.get('tool_name'):
+                    print(f"    Tool: {issue['tool_name']}", file=sys.stderr)
+
+        def _print_allowed_issues():
+            if not allowed_issues_found:
+                return
+            print("ℹ️  Allowed issues (not blocking):", file=sys.stderr)
+            for issue in allowed_issues_found:
+                print(
+                    f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
+                    file=sys.stderr,
+                )
 
         # Generate summary
         has_blocking_issues = len(blocking_issues) > 0
@@ -317,21 +372,24 @@ def main():
                 'analyzers': analyzers,
                 'blocking_issues': blocking_issues,
                 'blocking_count': len(blocking_issues),
+                'warning_issues': warning_issues,
+                'warning_count': len(warning_issues),
                 'allowed_issues': allowed_issues_found,
-                'allowed_count': len(allowed_issues_found)
+                'allowed_count': len(allowed_issues_found),
             }
 
             # Print human-readable output to stderr for CI logs
             print(f"❌ Security issues found in {server_name} that are not allowlisted:", file=sys.stderr)
             for issue in blocking_issues:
-                print(f"  - [{issue['code']}] {issue['message']}", file=sys.stderr)
+                print(
+                    f"  - [{issue['code']}] ({issue.get('severity')}) {issue['message']}",
+                    file=sys.stderr,
+                )
                 if issue.get('tool_name'):
                     print(f"    Tool: {issue['tool_name']}", file=sys.stderr)
 
-            if allowed_issues_found:
-                print(f"ℹ️  Allowed issues (not blocking):", file=sys.stderr)
-                for issue in allowed_issues_found:
-                    print(f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})", file=sys.stderr)
+            _print_warning_issues()
+            _print_allowed_issues()
 
             # Exit with error code to fail the CI step
             print(json.dumps(summary, indent=2))
@@ -344,20 +402,29 @@ def main():
                 'analyzers': analyzers,
                 'message': 'No blocking security issues detected'
             }
-
+            if warning_issues:
+                summary['warning_issues'] = warning_issues
+                summary['warning_count'] = len(warning_issues)
             if allowed_issues_found:
                 summary['allowed_issues'] = allowed_issues_found
                 summary['allowed_count'] = len(allowed_issues_found)
 
-                # Print info about allowed issues
-                print(f"ℹ️  Allowed security issues found in {server_name}:", file=sys.stderr)
-                for issue in allowed_issues_found:
-                    print(f"  - [{issue['code']}] {issue['message']}", file=sys.stderr)
-                    print(f"    Reason: {issue['allowed_reason']}", file=sys.stderr)
-                print(f"✅ All issues are allowlisted - build can proceed ({tools_scanned} tools scanned)", file=sys.stderr)
+            if warning_issues or allowed_issues_found:
+                print(
+                    f"ℹ️  Non-blocking findings in {server_name} ({tools_scanned} tools scanned):",
+                    file=sys.stderr,
+                )
+                _print_warning_issues()
+                _print_allowed_issues()
+                print(
+                    f"✅ Build can proceed — no blocking findings ({tools_scanned} tools scanned)",
+                    file=sys.stderr,
+                )
             else:
-                # Print success message to stderr for CI logs
-                print(f"✅ No security issues found in {server_name} ({tools_scanned} tools scanned)", file=sys.stderr)
+                print(
+                    f"✅ No security issues found in {server_name} ({tools_scanned} tools scanned)",
+                    file=sys.stderr,
+                )
 
             print(json.dumps(summary, indent=2))
 

--- a/scripts/skill-scan/process_scan_results.py
+++ b/scripts/skill-scan/process_scan_results.py
@@ -20,6 +20,24 @@ import yaml
 
 GLOBAL_CONFIG_FILE = os.path.join(os.path.dirname(__file__), "global_allowed_issues.yaml")
 
+# Higher rank = more severe. Unknown severities are treated as blocking (rank
+# = max + 1) so an unrecognized value never silently slips past the gate.
+SEVERITY_RANK = {"INFO": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4}
+DEFAULT_BLOCK_SEVERITY = "HIGH"
+
+
+def _block_severity_threshold() -> int:
+    raw = os.environ.get("SKILL_SCANNER_BLOCK_SEVERITY", DEFAULT_BLOCK_SEVERITY)
+    rank = SEVERITY_RANK.get((raw or "").strip().upper())
+    return rank if rank is not None else SEVERITY_RANK[DEFAULT_BLOCK_SEVERITY]
+
+
+def _is_blocking_severity(severity: str | None, threshold: int) -> bool:
+    rank = SEVERITY_RANK.get((severity or "").strip().upper())
+    if rank is None:
+        return True
+    return rank >= threshold
+
 
 def _load_allowed_entries(path: str) -> list[dict]:
     if not os.path.exists(path):
@@ -71,9 +89,13 @@ def match_allowlist(finding: dict, entries: list[dict]) -> tuple[bool, str | Non
     return False, None
 
 
-def classify_findings(scan: dict, entries: list[dict]) -> tuple[list[dict], list[dict]]:
+def classify_findings(
+    scan: dict, entries: list[dict]
+) -> tuple[list[dict], list[dict], list[dict]]:
     blocking: list[dict] = []
+    warnings: list[dict] = []
     allowed: list[dict] = []
+    threshold = _block_severity_threshold()
     for finding in scan.get("findings") or []:
         if not isinstance(finding, dict):
             continue
@@ -92,9 +114,11 @@ def classify_findings(scan: dict, entries: list[dict]) -> tuple[list[dict], list
         if is_allowed:
             detail["allowed_reason"] = reason
             allowed.append(detail)
-        else:
+        elif _is_blocking_severity(finding.get("severity"), threshold):
             blocking.append(detail)
-    return blocking, allowed
+        else:
+            warnings.append(detail)
+    return blocking, warnings, allowed
 
 
 def _warn_summary(skill_name: str, message: str) -> dict:
@@ -160,9 +184,43 @@ def main() -> None:
         print(json.dumps(summary, indent=2))
         sys.exit(0 if insecure_ignore else 1)
 
-    blocking, allowed = classify_findings(scan, entries)
+    blocking, warnings, allowed = classify_findings(scan, entries)
     analyzers = scan.get("analyzers_used") or []
     findings_count = scan.get("findings_count", len(scan.get("findings") or []))
+
+    def _format_loc(issue: dict) -> str:
+        if not issue.get("file_path"):
+            return ""
+        loc = f" ({issue['file_path']}"
+        if issue.get("line_number"):
+            loc += f":{issue['line_number']}"
+        return loc + ")"
+
+    def _print_warnings() -> None:
+        if not warnings:
+            return
+        threshold_name = os.environ.get(
+            "SKILL_SCANNER_BLOCK_SEVERITY", DEFAULT_BLOCK_SEVERITY
+        ).upper()
+        print(
+            f"Below-threshold findings (block threshold = {threshold_name}, not blocking):",
+            file=sys.stderr,
+        )
+        for issue in warnings:
+            print(
+                f"  - [{issue['code']}] ({issue['severity']}) {issue['message']}{_format_loc(issue)}",
+                file=sys.stderr,
+            )
+
+    def _print_allowed() -> None:
+        if not allowed:
+            return
+        print("Allowlisted (not blocking):", file=sys.stderr)
+        for issue in allowed:
+            print(
+                f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
+                file=sys.stderr,
+            )
 
     if blocking:
         summary = {
@@ -172,29 +230,19 @@ def main() -> None:
             "analyzers": analyzers,
             "blocking_issues": blocking,
             "blocking_count": len(blocking),
+            "warning_issues": warnings,
+            "warning_count": len(warnings),
             "allowed_issues": allowed,
             "allowed_count": len(allowed),
         }
         print(f"Skill security scan FAILED for {skill_name}:", file=sys.stderr)
         for issue in blocking:
-            if issue.get("file_path"):
-                loc = f" ({issue['file_path']}"
-                if issue.get("line_number"):
-                    loc += f":{issue['line_number']}"
-                loc += ")"
-            else:
-                loc = ""
             print(
-                f"  - [{issue['code']}] ({issue['severity']}) {issue['message']}{loc}",
+                f"  - [{issue['code']}] ({issue['severity']}) {issue['message']}{_format_loc(issue)}",
                 file=sys.stderr,
             )
-        if allowed:
-            print(f"Allowlisted (not blocking):", file=sys.stderr)
-            for issue in allowed:
-                print(
-                    f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
-                    file=sys.stderr,
-                )
+        _print_warnings()
+        _print_allowed()
         print(json.dumps(summary, indent=2))
         sys.exit(1)
 
@@ -205,15 +253,20 @@ def main() -> None:
         "analyzers": analyzers,
         "message": "No blocking security issues detected",
     }
+    if warnings:
+        summary["warning_issues"] = warnings
+        summary["warning_count"] = len(warnings)
     if allowed:
         summary["allowed_issues"] = allowed
         summary["allowed_count"] = len(allowed)
-        print(f"Skill security scan passed for {skill_name} with allowlisted findings:", file=sys.stderr)
-        for issue in allowed:
-            print(
-                f"  - [{issue['code']}] {issue['message']} (Allowed: {issue['allowed_reason']})",
-                file=sys.stderr,
-            )
+
+    if warnings or allowed:
+        print(
+            f"Skill security scan passed for {skill_name} with non-blocking findings:",
+            file=sys.stderr,
+        )
+        _print_warnings()
+        _print_allowed()
     else:
         print(f"Skill security scan passed for {skill_name} (no findings)", file=sys.stderr)
     print(json.dumps(summary, indent=2))


### PR DESCRIPTION
## Summary

- Block CI scan jobs only on findings at or above a configurable severity threshold (default `HIGH`); surface lower findings as warnings.
- Apply to both `scripts/skill-scan/process_scan_results.py` and `scripts/mcp-scan/process_scan_results.py` — they had identical code shape `else: blocking.append(...)` that ignored the `severity` field entirely.
- Threshold is hardcoded in workflow YAML (`SKILL_SCANNER_BLOCK_SEVERITY` / `MCP_SCANNER_BLOCK_SEVERITY`) so policy changes go through PR review rather than a repo-variable edit.

## Why

After enabling the LLM analyzer for skill-scan, PR #557 started failing on LOW-severity LLM findings like "subprocess.run without a timeout" alongside the real HIGH/CRITICAL pattern matches. The intent of the gate is to block on serious issues, not noise.

The MCP processor has the identical structural gap; fixing both keeps them in sync, but note this side has not been observed manifesting because most recent MCP scans short-circuit before producing findings (0 tools scanned).

## Test plan

- [x] Synthetic skill-scan input with one finding per severity level — at default `HIGH`, only HIGH/CRITICAL block; LOW/MEDIUM/INFO appear as warnings in stderr and in `warning_issues` in the summary JSON. Exit 1 only when blocking findings exist.
- [x] Synthetic MCP-scan input with mixed CRITICAL+LOW — at `HIGH`, CRITICAL blocks, LOW becomes a warning, exit 1.
- [x] Synthetic MCP-scan input with LOW only — at `HIGH`, exit 0, warning surfaced.
- [x] `python3 -m py_compile` and `yaml.safe_load` both pass on the four touched files.
- [ ] Confirm PR #557 (renovate forge-skills digest) goes green after rebasing on this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)