### PR TITLE
fix(skills): per-cell scan gate in build-skills workflow

### DIFF
--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -274,7 +274,12 @@ jobs:
     needs: [discover-skill-configs, validate-skills, skill-security-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' && (needs.skill-security-scan.result == 'success' || needs.skill-security-scan.result == 'skipped') }}
+    # Aggregate scan result is intentionally not gated here. A failure in one
+    # skill's scan must not block publishing the rest. The per-cell
+    # `Pre-flight scan gate` step below preserves the security gate at the
+    # individual skill level by reading scan-summary.json from the artifact
+    # produced by skill-security-scan (uploaded with `if: always()`).
+    if: ${{ !cancelled() && needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-skill-configs.outputs.changed-configs) }}
@@ -334,6 +339,60 @@ jobs:
 
           image_name="${REGISTRY}/${{ github.repository }}/skills/${skill_name}"
           echo "image_name=$image_name" >> $GITHUB_OUTPUT
+
+      # Pull the per-skill security scan artifact early, before we spend time
+      # building. `continue-on-error: true` so this step succeeds when the
+      # artifact does not exist (i.e. this skill was not in scan-configs for
+      # this run); the next step decides whether that is acceptable.
+      - name: Download skill security scan results
+        id: download-scan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: skill-scan-${{ steps.meta.outputs.skill_name }}
+          path: /tmp/skill-scan-results
+        continue-on-error: true
+
+      # Per-cell scan gate. Replaces the old aggregate
+      # `needs.skill-security-scan.result == 'success'` check at the job
+      # level so that one skill's scan failure cannot starve out the rest.
+      # - If this skill was in scan-configs for this run, require a fresh
+      #   scan-summary.json with status in {passed, warning}. Anything else
+      #   fails the cell, preserving the security gate per skill.
+      # - If this skill was NOT in scan-configs (e.g. go.mod-only push that
+      #   rebuilds everything but only re-scans changed specs), proceed on
+      #   prior trust: the previous run on main must have been clean for the
+      #   pinned ref to land here.
+      - name: Pre-flight scan gate
+        env:
+          CONFIG: ${{ matrix.config }}
+          SCAN_CONFIGS: ${{ needs.discover-skill-configs.outputs.scan-configs }}
+          SKILL_NAME: ${{ steps.meta.outputs.skill_name }}
+        run: |
+          set -euo pipefail
+          summary=/tmp/skill-scan-results/scan-summary.json
+
+          expected=$(jq -r --arg c "$CONFIG" 'index($c) // "missing"' <<<"$SCAN_CONFIGS")
+
+          if [ ! -f "$summary" ]; then
+            if [ "$expected" = "missing" ]; then
+              echo "No scan ran for ${SKILL_NAME} in this workflow (not in scan-configs); proceeding on prior trust."
+              exit 0
+            fi
+            echo "::error title=Scan artifact missing::scan-summary.json absent for ${SKILL_NAME} but the skill was in scan-configs; refusing to publish."
+            exit 1
+          fi
+
+          status=$(jq -r '.status // "missing"' "$summary")
+          case "$status" in
+            passed|warning)
+              echo "Skill scan status for ${SKILL_NAME}: ${status} - publish allowed."
+              ;;
+            *)
+              echo "::error title=Scan blocked publish::Skill ${SKILL_NAME} scan status is '${status}'; refusing to publish."
+              jq -r '.blocking_issues[]? | "  - [\(.code)] (\(.severity)) \(.message)"' "$summary" 2>/dev/null || true
+              exit 1
+              ;;
+          esac
 
       - name: Build dockhand
         run: go build -o /tmp/dockhand ./cmd/dockhand
@@ -450,15 +509,6 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
-      - name: Download skill security scan results
-        id: download-scan
-        if: github.event_name != 'pull_request' && steps.build.outputs.digest != ''
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: skill-scan-${{ steps.meta.outputs.skill_name }}
-          path: /tmp/skill-scan-results
-        continue-on-error: false
-
       - name: Create security scan attestation (SCAI format)
         if: github.event_name != 'pull_request' && steps.build.outputs.digest != ''
         env:
@@ -471,6 +521,15 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+
+          # Prior-trust path: this skill was not in scan-configs for this run
+          # (e.g. go.mod-only push that rebuilds everything but only re-scans
+          # changed specs). The previous SCAI attestation on the registry
+          # remains authoritative; skipping here is safe and intentional.
+          if [ ! -f /tmp/skill-scan-results/scan-summary.json ]; then
+            echo "No fresh scan summary for this run; skipping SCAI attestation (skill not in this run's scan-configs)."
+            exit 0
+          fi
 
           SCANNER_VERSION=""
           if [ -f /tmp/skill-scan-results/scanner-version.txt ]; then


### PR DESCRIPTION
## Summary

- The `build-skill-artifacts` matrix in [`.github/workflows/build-skills.yml`](.github/workflows/build-skills.yml) was gated on the aggregate result of `skill-security-scan`. A `workflow_dispatch` rebuild with 89/131 scans clean and 42/131 blocking tripped the aggregate to `failure` and the entire matrix was skipped, so the 89 healthy skills also never republished. The same shape happened on `go.mod`-only pushes, where `scan-configs` was empty, the scan job was conditionally skipped, and the build matrix got skipped along with it.
- Per-skill data is already there to gate per-cell. [`scripts/skill-scan/process_scan_results.py`](scripts/skill-scan/process_scan_results.py) writes `scan-summary.json` even on failure (`status: failed` plus `blocking_issues`), and the scan job uploads it with `if: always()` under a per-skill artifact name.
- Replace the aggregate gate with a per-cell `Pre-flight scan gate`: download the per-skill scan artifact early (`continue-on-error: true`), then either require `status in {passed, warning}` for a skill that was in this run's `scan-configs`, or proceed on prior trust when the skill was not re-scanned in this run.
- Collapse the late `Download skill security scan results` step into the new early one, and teach the SCAI attestation step to skip cleanly when no fresh `scan-summary.json` exists.

## Type of change

- [x] Bug fix (CI gate)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build-skills.yml` | Drop `needs.skill-security-scan.result` from the `build-skill-artifacts` aggregate gate. Add early `Download skill security scan results` (continue-on-error) + new `Pre-flight scan gate` step. Remove the now-redundant late download. SCAI attestation step short-circuits cleanly when no fresh summary exists. |

## Behaviour after this change

- `workflow_dispatch` (full rebuild): all 131 cells expand. Cells whose scan passed publish + sign + attest as today. Cells whose own scan blocks fail visibly with an `::error::` annotation pointing at the blocking findings. Failures stay scoped to their own cell.
- `push` of a Renovate-style spec digest bump: unchanged (per-cell scan + per-cell gate, exactly as today).
- `push` of `go.mod` / `go.sum` only (e.g. the [#582](https://github.com/stacklok/dockyard/pull/582) toolhive bump that just merged): now actually rebuilds and publishes all 131 skills, gated by prior trust. SCAI attestations on those rebuilds skip cleanly; existing on-registry SCAI remains authoritative.
- PR runs: still dry-run only (the existing `Build skill artifact` step's `PUSH=${{ github.event_name != 'pull_request' }}` is unchanged).

## Test plan

- [x] `actionlint` (via `rhysd/actionlint:1.7.7`) clean on the workflow file (no shellcheck regressions in the new regions).
- [x] `yq` parses the workflow and the new step ordering is `Extract metadata -> Download scan -> Pre-flight gate -> Build dockhand -> Build skill artifact -> ... -> SCAI attestation`.
- [x] Trigger the workflow via `workflow_dispatch` from this branch and confirm the 89/42 split lands as expected: 89 cells succeed with `Publish: yes`, 42 cells fail at `Pre-flight scan gate` with the new error annotation.

## Does this introduce a user-facing change?

No behavioural change for skills whose scan currently passes - they continue to publish on every triggering event. Skills whose scan blocks now fail in their own matrix cell instead of skipping the entire build matrix. As a positive side-effect, `go.mod`-only pushes (which previously skipped the build matrix entirely) now rebuild and publish all skills.


Made with [Cursor](https://cursor.com)