### PR TITLE
feat(skills): add 5 skills from entireio/skills

### DIFF
--- a/skills/entire-explain/spec.yaml
+++ b/skills/entire-explain/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/entireio/skills"
-  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  ref: "c376dc971045eb38c094802ca43875d1cfa00ea4"  # main as of 2026-05-07
   path: "skills/explain"
   version: "0.1.0"
 

--- a/skills/entire-explain/spec.yaml
+++ b/skills/entire-explain/spec.yaml
@@ -1,0 +1,23 @@
+# Entire explain Skill
+# Explain code intent by tracing it back to the original Entire session transcript.
+# Source: https://github.com/entireio/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/entire-explain:0.1.0
+
+metadata:
+  name: entire-explain
+  description: "Explain the intent behind a function, file, or line by tracing it back to the original Entire session transcript that produced it."
+
+spec:
+  repository: "https://github.com/entireio/skills"
+  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  path: "skills/explain"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/entireio/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "entireio/skills is MIT-licensed at the repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/entire-search/spec.yaml
+++ b/skills/entire-search/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/entireio/skills"
-  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  ref: "c376dc971045eb38c094802ca43875d1cfa00ea4"  # main as of 2026-05-07
   path: "skills/search"
   version: "0.1.0"
 

--- a/skills/entire-search/spec.yaml
+++ b/skills/entire-search/spec.yaml
@@ -1,0 +1,23 @@
+# Entire search Skill
+# Find prior work, checkpoints, and agent conversations in Entire history before guessing from memory.
+# Source: https://github.com/entireio/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/entire-search:0.1.0
+
+metadata:
+  name: entire-search
+  description: "Find prior work, checkpoints, or agent conversations in Entire history by topic, repo, branch, author, or recent time window. Use before guessing from memory."
+
+spec:
+  repository: "https://github.com/entireio/skills"
+  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  path: "skills/search"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/entireio/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "entireio/skills is MIT-licensed at the repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/entire-session-handoff/spec.yaml
+++ b/skills/entire-session-handoff/spec.yaml
@@ -1,0 +1,23 @@
+# Entire session-handoff Skill
+# Hand off the current or a saved Entire session to another agent with state, discoveries, and next steps.
+# Source: https://github.com/entireio/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/entire-session-handoff:0.1.0
+
+metadata:
+  name: entire-session-handoff
+  description: "Hand off the current or a saved Entire session to another agent. Inspects recent sessions and produces a handoff summary covering state, discoveries, blockers, and next steps."
+
+spec:
+  repository: "https://github.com/entireio/skills"
+  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  path: "skills/session-handoff"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/entireio/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "entireio/skills is MIT-licensed at the repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/entire-session-handoff/spec.yaml
+++ b/skills/entire-session-handoff/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/entireio/skills"
-  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  ref: "c376dc971045eb38c094802ca43875d1cfa00ea4"  # main as of 2026-05-07
   path: "skills/session-handoff"
   version: "0.1.0"
 

--- a/skills/entire-session-to-skill/spec.yaml
+++ b/skills/entire-session-to-skill/spec.yaml
@@ -1,0 +1,23 @@
+# Entire session-to-skill Skill
+# Turn Entire-tracked sessions, checkpoints, or repeated agent workflows into reusable SKILL.md drafts.
+# Source: https://github.com/entireio/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/entire-session-to-skill:0.1.0
+
+metadata:
+  name: entire-session-to-skill
+  description: "Turn one or more Entire-tracked sessions, checkpoints, or repeated agent workflows into a reusable SKILL.md draft."
+
+spec:
+  repository: "https://github.com/entireio/skills"
+  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  path: "skills/session-to-skill"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/entireio/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "entireio/skills is MIT-licensed at the repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/entire-session-to-skill/spec.yaml
+++ b/skills/entire-session-to-skill/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/entireio/skills"
-  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  ref: "c376dc971045eb38c094802ca43875d1cfa00ea4"  # main as of 2026-05-07
   path: "skills/session-to-skill"
   version: "0.1.0"
 

--- a/skills/entire-what-happened/spec.yaml
+++ b/skills/entire-what-happened/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/entireio/skills"
-  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  ref: "c376dc971045eb38c094802ca43875d1cfa00ea4"  # main as of 2026-05-07
   path: "skills/what-happened"
   version: "0.1.0"
 

--- a/skills/entire-what-happened/spec.yaml
+++ b/skills/entire-what-happened/spec.yaml
@@ -1,0 +1,23 @@
+# Entire what-happened Skill
+# Trace the latest change for a file range or pasted snippet via git blame plus Entire explain.
+# Source: https://github.com/entireio/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/entire-what-happened:0.1.0
+
+metadata:
+  name: entire-what-happened
+  description: "Trace the latest change for a file range, line, or pasted snippet via `git blame` plus deduplicated `entire explain` lookups. Use when the user asks what happened, why a block was changed, or wants provenance for a specific section."
+
+spec:
+  repository: "https://github.com/entireio/skills"
+  ref: "33d2f7ef206b08781fad6481611bae3d3a4ab8d4"  # main as of 2026-05-05
+  path: "skills/what-happened"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/entireio/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "entireio/skills is MIT-licensed at the repo root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Add packaging specs for all 5 skills shipped by [entireio/skills](https://github.com/entireio/skills) (MIT-licensed), pinned to commit `c376dc971045eb38c094802ca43875d1cfa00ea4` (`main` as of 2026-05-07) at dockyard version `0.1.0`. Each spec follows the existing `mattpocock/skills` template (e.g. [`skills/tdd/spec.yaml`](https://github.com/stacklok/dockyard/blob/main/skills/tdd/spec.yaml)).

These skills teach agents how to use the [Entire CLI](https://entire.io) — searching prior checkpoints and sessions, explaining the intent behind code, and handing off in-flight work between agents.

### Skills added

- **Context lookup (3)**: `entire-search`, `entire-explain`, `entire-what-happened`
- **Session lifecycle (2)**: `entire-session-handoff`, `entire-session-to-skill`

Each upstream name is prefixed with `entire-` in dockyard to avoid collisions with the generic terms (`search`, `explain`, …) and to keep provenance clear in the agent skill list. The upstream `name:` field inside each `SKILL.md` is left untouched.

### Upstream coordination

`skills/what-happened/SKILL.md` originally declared `name: What Happened` (capitalized, with a space), which failed dockhand's slug validator (`must be 2-64 lowercase alphanumeric characters or hyphens`). Fixed upstream in [entireio/skills#23](https://github.com/entireio/skills/pull/23); the pin in this PR includes that fix.

### Note on `entire-session-to-skill`

`session-to-skill` is included even though its README section was removed upstream in [entireio/skills#21](https://github.com/entireio/skills/pull/21): the skill directory still exists at the pinned commit and its `SKILL.md` is well-formed, so it ships alongside the others.

### Allowlist

Each spec allowlists `MANIFEST_MISSING_LICENSE` with the same reason used for `mattpocock/skills`: `entireio/skills` carries its MIT license at the repository root rather than embedding an SPDX identifier in per-skill `SKILL.md` frontmatter.

## Test plan

- [x] CI `validate-skills` matrix passes for the 5 new configs.
- [x] CI `skill-security-scan` passes; only `MANIFEST_MISSING_LICENSE` findings remain and are allowlisted.
- [x] CI `build-skill-artifacts` (dry-run on PR) succeeds.
