### PR TITLE
feat(skills): add automated semver versioning for skill ref updates

### DIFF
--- a/.github/workflows/skill-version-check.yml
+++ b/.github/workflows/skill-version-check.yml
@@ -40,10 +40,13 @@ jobs:
           go run ./cmd/skillversionbump \
             --base "$GITHUB_BASE_SHA"
 
-  # skill-version-autofix runs only for the Renovate bot.  It writes the
-  # correct version back to the branch so the PR stays green without manual
-  # intervention.  Uses pull_request_target so it has write access to the
-  # branch; the extra permissions are intentional and documented below.
+  # skill-version-autofix runs only for the Renovate / Dependabot bots and
+  # only when their PR comes from a branch in this repo (Renovate creates
+  # branches here, not forks).  It uses the standard `pull_request` trigger
+  # plus `permissions: contents: write` to commit the corrected version back
+  # to the PR branch — no `pull_request_target` is needed (and avoiding it
+  # is safer: pull_request_target would run the head ref with elevated
+  # permissions, which is the classic supply-chain footgun).
   skill-version-autofix:
     name: Auto-fix skill spec.version (Renovate only)
     runs-on: ubuntu-latest
@@ -94,5 +97,12 @@ jobs:
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add 'skills/*/spec.yaml'
-          git commit -m "chore(skills): bump spec.version for updated refs"
+
+          # Build a list of skill names from the staged spec.yaml paths so the
+          # commit message is greppable in `git log` (e.g. "huggingface-skills,
+          # mattpocock-skills").
+          skills=$(git diff --cached --name-only -- 'skills/*/spec.yaml' \
+            | awk -F/ '{print $2}' | sort -u | paste -sd, -)
+
+          git commit -m "chore(skills): bump spec.version for ${skills}"
           git push

--- a/.github/workflows/skill-version-check.yml
+++ b/.github/workflows/skill-version-check.yml
@@ -1,0 +1,98 @@
+name: Skill Version Check
+
+# Run on every PR that touches a skill spec.yaml.  The check is path-filtered
+# so it is a no-op on PRs that do not change any skill.
+#
+# The job calls `skillversionbump --check` (read-only) for all PR authors.
+# The optional auto-fix job runs only for the Renovate bot and commits the
+# corrected version back to the PR branch.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/**/spec.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  skill-version-check:
+    name: Check skill spec.version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Fetch enough history so `git show <base>:<path>` works.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check skill versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          go run ./cmd/skillversionbump \
+            --base "$GITHUB_BASE_SHA"
+
+  # skill-version-autofix runs only for the Renovate bot.  It writes the
+  # correct version back to the branch so the PR stays green without manual
+  # intervention.  Uses pull_request_target so it has write access to the
+  # branch; the extra permissions are intentional and documented below.
+  skill-version-autofix:
+    name: Auto-fix skill spec.version (Renovate only)
+    runs-on: ubuntu-latest
+    # Only apply the auto-fix for the Renovate bot.
+    if: >
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'dependabot[bot]'
+    # Write access is needed to commit back to the PR branch.
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          # Use the head ref directly so we can push to it.
+          ref: ${{ github.event.pull_request.head.ref }}
+          # A bot token with write access is required here.
+          # Replace with a PAT or GitHub App token if GITHUB_TOKEN
+          # does not have push rights on your repo configuration.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Apply skill version bumps
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          go run ./cmd/skillversionbump \
+            --base "$GITHUB_BASE_SHA" \
+            --write
+
+          # Check whether anything was actually modified
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit version bumps
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add 'skills/*/spec.yaml'
+          git commit -m "chore(skills): bump spec.version for updated refs"
+          git push

--- a/cmd/skillversionbump/main.go
+++ b/cmd/skillversionbump/main.go
@@ -108,6 +108,9 @@ func run(cmd *cobra.Command, cfg skillversion.Config, specPaths []string) error 
 			cmd.Printf("  FAIL   %s  version %s should be %s (%s bump)\n",
 				r.SpecPath, r.CurrentVersion, r.ExpectedVersion, r.Bump)
 		}
+		if r.APIError != "" {
+			cmd.Printf("           ⚠ heuristic ran without GitHub data: %s\n", r.APIError)
+		}
 	}
 
 	if !cfg.Write {

--- a/cmd/skillversionbump/main.go
+++ b/cmd/skillversionbump/main.go
@@ -30,13 +30,11 @@ func main() {
 }
 
 func newRootCmd() *cobra.Command {
-	var (
-		baseRef     string
-		write       bool
-		skipAPI     bool
-		token       string
-		specPaths   []string
-	)
+	var baseRef string
+	var write bool
+	var skipAPI bool
+	var token string
+	var specPaths []string
 
 	cmd := &cobra.Command{
 		Use:   "skillversionbump",

--- a/cmd/skillversionbump/main.go
+++ b/cmd/skillversionbump/main.go
@@ -1,0 +1,137 @@
+// Command skillversionbump checks or updates spec.version in skills/*/spec.yaml
+// when spec.ref has changed between the PR base and HEAD.
+//
+// Usage (check mode — exits non-zero if any version is wrong):
+//
+//	go run ./cmd/skillversionbump --base origin/main
+//
+// Usage (write mode — updates spec.yaml files on disk):
+//
+//	go run ./cmd/skillversionbump --base origin/main --write
+//
+// In GitHub Actions the base SHA is available as GITHUB_BASE_SHA:
+//
+//	go run ./cmd/skillversionbump --base "$GITHUB_BASE_SHA"
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stacklok/dockyard/internal/skillversion"
+)
+
+func main() {
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newRootCmd() *cobra.Command {
+	var (
+		baseRef     string
+		write       bool
+		skipAPI     bool
+		token       string
+		specPaths   []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "skillversionbump",
+		Short: "Check or update spec.version in skill spec.yaml files when spec.ref changes",
+		Long: `skillversionbump enforces Dockyard's semver policy for vendored skills.
+
+When spec.ref changes between the PR base and HEAD, spec.version must also be
+bumped.  The tool applies a heuristic to decide between a patch and a minor
+bump (see internal/skillversion/heuristic.go for thresholds):
+
+  - minor if total line churn in the skill subtree >= 120 lines
+  - minor if SKILL.md is touched and churn >= 40 lines
+  - minor if any commit in range has a feat/feature conventional-commit prefix
+  - patch otherwise
+
+Major version bumps are intentionally left to human judgment.
+
+Run without --write to check (CI mode); run with --write to apply fixes.`,
+		Example: `  # Check all changed specs against origin/main (CI usage)
+  skillversionbump --base origin/main
+
+  # Fix versions in changed specs automatically
+  skillversionbump --base origin/main --write
+
+  # Check a specific spec file
+  skillversionbump --base origin/main --spec skills/my-skill/spec.yaml
+
+  # Skip GitHub API (patch-only, offline)
+  skillversionbump --base origin/main --skip-api`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return run(cmd, skillversion.Config{
+				BaseRef:     baseRef,
+				Token:       token,
+				Write:       write,
+				SkipAPICall: skipAPI,
+			}, specPaths)
+		},
+	}
+
+	cmd.Flags().StringVarP(&baseRef, "base", "b", envOrDefault("GITHUB_BASE_SHA", "origin/main"),
+		"Base git ref (SHA or branch) to compare against. Defaults to $GITHUB_BASE_SHA or origin/main.")
+	cmd.Flags().BoolVar(&write, "write", false,
+		"Update spec.yaml files on disk instead of just checking them.")
+	cmd.Flags().BoolVar(&skipAPI, "skip-api", false,
+		"Skip the GitHub compare API and always apply a patch bump (useful offline).")
+	cmd.Flags().StringVar(&token, "token", envOrDefault("GITHUB_TOKEN", os.Getenv("GH_TOKEN")),
+		"GitHub API token. Defaults to $GITHUB_TOKEN or $GH_TOKEN.")
+	cmd.Flags().StringArrayVarP(&specPaths, "spec", "s", nil,
+		"Specific spec.yaml path(s) to check. If omitted, all changed skills/*/spec.yaml are discovered via git diff.")
+
+	return cmd
+}
+
+func run(cmd *cobra.Command, cfg skillversion.Config, specPaths []string) error {
+	ctx := context.Background()
+
+	results, err := skillversion.ProcessSpecs(ctx, cfg, specPaths)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range results {
+		switch {
+		case r.Skipped:
+			cmd.Printf("  skip   %s (ref unchanged or new file)\n", r.SpecPath)
+		case r.UpToDate && cfg.Write:
+			cmd.Printf("  wrote  %s  %s → %s (%s)\n", r.SpecPath, r.OldVersion, r.CurrentVersion, r.Bump)
+		case r.UpToDate:
+			cmd.Printf("  ok     %s  version %s is correct\n", r.SpecPath, r.CurrentVersion)
+		default:
+			cmd.Printf("  FAIL   %s  version %s should be %s (%s bump)\n",
+				r.SpecPath, r.CurrentVersion, r.ExpectedVersion, r.Bump)
+		}
+	}
+
+	if !cfg.Write {
+		if checkErr := skillversion.CheckErrors(results); checkErr != nil {
+			return checkErr
+		}
+	}
+
+	checked := 0
+	for _, r := range results {
+		if !r.Skipped {
+			checked++
+		}
+	}
+	cmd.Printf("\n%d spec(s) checked, %d skipped (ref unchanged)\n",
+		checked, len(results)-checked)
+	return nil
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ You're evaluating Dockyard for security compliance or want to verify container i
 | [Security Overview](security.md) | Security model and scanning |
 | [Attestations](attestations.md) | Container attestation details |
 | [Provenance](provenance.md) | Package provenance verification |
+| [Skill Versioning](skill-versioning.md) | Semver policy and auto-bump tooling for skills |
 
 ## Additional Resources
 

--- a/docs/skill-versioning.md
+++ b/docs/skill-versioning.md
@@ -66,6 +66,15 @@ before merging.
    branch.
 4. Once both jobs pass the PR can be merged.
 
+> **Note on workflow re-triggering:** the autofix job commits back to the PR
+> branch using the default `GITHUB_TOKEN`. By design, GitHub does **not**
+> trigger downstream workflows (including `skill-version-check`) for events
+> created by `GITHUB_TOKEN` to prevent recursion. The check job that already
+> ran on the previous commit remains the gate; the autofix commit will not
+> re-run it. If you need re-triggering (e.g. to surface a new validation
+> failure introduced by the auto-bump), use a PAT or GitHub App token in the
+> workflow `checkout` step instead of `secrets.GITHUB_TOKEN`.
+
 ### Human PRs
 
 If you manually change `spec.ref`, run the tool locally before pushing:

--- a/docs/skill-versioning.md
+++ b/docs/skill-versioning.md
@@ -1,0 +1,105 @@
+# Skill Versioning Policy
+
+Dockyard packages skills from external git repositories into OCI artifacts.
+Because most upstream skill repositories do not publish per-skill version tags,
+**Dockyard owns the semver for every vendored skill** via the `spec.version`
+field in each `skills/*/spec.yaml`.
+
+## Why spec.version matters
+
+The build workflow (`build-skills.yml`) tags OCI images using `spec.version`:
+
+```bash
+IMAGE_REF="ghcr.io/stacklok/dockyard/skills/<name>:<spec.version>"
+```
+
+Publishing new content under the same tag would silently overwrite a pinned
+image.  Every time `spec.ref` changes, `spec.version` must change too so
+consumers always get what the tag promises.
+
+## Semver rules
+
+| Change type | What to bump | When |
+|-------------|-------------|------|
+| New upstream snapshot (small fixes, typos) | **patch** | Default for all `spec.ref` advances |
+| New upstream snapshot with substantial changes | **minor** | See heuristic below |
+| Incompatible behavior change | **major** | Manual — never auto-bumped |
+
+## The minor-bump heuristic
+
+`cmd/skillversionbump` runs the GitHub compare API between the old and new
+`spec.ref` values, filters the diff to files inside `spec.path`, and applies
+this logic (constants live in `internal/skillversion/heuristic.go`):
+
+1. **minor** — total lines added + deleted in the skill subtree ≥ **120**
+2. **minor** — `SKILL.md` is among the changed files **and** total churn ≥ **40** lines
+3. **minor** — any commit in range has a `feat:` / `feat(scope):` / `feature:`
+   conventional-commit prefix
+4. **patch** — otherwise (default)
+
+To tune these thresholds, edit the constants at the top of
+`internal/skillversion/heuristic.go` and commit; no logic changes are needed.
+
+## Major / breaking changes
+
+Major bumps are **never automated**.  Reviewers should apply a major bump when:
+
+- A tool name, argument signature, or SKILL.md frontmatter field is renamed
+  or removed.
+- The skill's described capabilities change in a backwards-incompatible way.
+- Commit messages in the compare range include `BREAKING CHANGE:` or a `!`
+  marker (e.g. `feat!: ...`).
+
+After reviewing the diff, simply edit `spec.version` to the next major version
+before merging.
+
+## Workflow
+
+### Renovate PRs (automated digest bumps)
+
+1. Renovate opens a PR updating only `spec.ref` in one or more
+   `skills/*/spec.yaml` files.
+2. The **`skill-version-check`** CI job runs `skillversionbump --check` and
+   fails because `spec.version` has not changed.
+3. The **`skill-version-autofix`** job (Renovate only) runs
+   `skillversionbump --write` and commits the corrected versions back to the
+   branch.
+4. Once both jobs pass the PR can be merged.
+
+### Human PRs
+
+If you manually change `spec.ref`, run the tool locally before pushing:
+
+```bash
+go run ./cmd/skillversionbump --base origin/main --write
+```
+
+Then commit the updated `spec.yaml` files together with your ref changes.
+
+## Overriding the heuristic
+
+If the tool suggests **patch** but you know the update is **minor** (or vice
+versa), simply set `spec.version` to the version you want before pushing.  The
+check step accepts any version that is strictly higher than the previous one;
+it only rejects versions that have not been bumped at all.
+
+```bash
+# Manually set a minor bump instead of the suggested patch
+# Edit skills/my-skill/spec.yaml and set version: "0.2.0", then:
+git add skills/my-skill/spec.yaml
+git commit -m "fix: bump my-skill to 0.2.0 (minor — adds new tool)"
+```
+
+## Local usage reference
+
+```
+Usage:
+  skillversionbump [flags]
+
+Flags:
+  -b, --base string    Base git ref (SHA or branch). Default: $GITHUB_BASE_SHA or origin/main
+      --write          Update spec.yaml files on disk (default: check only)
+      --skip-api       Skip GitHub compare API; always apply patch bump (offline use)
+      --token string   GitHub API token. Default: $GITHUB_TOKEN or $GH_TOKEN
+  -s, --spec string    Specific spec.yaml path(s) to check (repeatable)
+```

--- a/internal/skillversion/bump.go
+++ b/internal/skillversion/bump.go
@@ -72,8 +72,7 @@ func processOneSpec(ctx context.Context, cfg Config, path string) (BumpResult, e
 
 	base, err := readBaseSpec(cfg.BaseRef, path)
 	if err != nil {
-		// File may be new (no base); treat as needing a patch bump from 0.1.0.
-		// We skip it here — the PR author must set an initial version.
+		// File may be new (no base); skip — PR author must set an initial version.
 		return BumpResult{SpecPath: path, Skipped: true}, nil
 	}
 
@@ -90,49 +89,54 @@ func processOneSpec(ctx context.Context, cfg Config, path string) (BumpResult, e
 		return result, nil
 	}
 
-	// ref changed — compute expected version
-	var signals ChangeSignals
-	if !cfg.SkipAPICall && head.Spec.Repository != "" && base.Spec.Ref != "" && head.Spec.Ref != "" {
-		owner, repo, err := parseGitHubRepo(head.Spec.Repository)
-		if err == nil {
-			signals, err = computeSignals(ctx, cfg.Token, owner, repo, base.Spec.Ref, head.Spec.Ref, head.Spec.Path)
-			if err != nil {
-				// Non-fatal: fall back to patch if the API is unreachable.
-				fmt.Printf("warning: GitHub compare API failed for %s: %v (defaulting to patch)\n", path, err)
-			}
-		}
-	}
-
-	bump := DetermineBump(signals)
-	result.Bump = bump
+	signals := fetchSignals(ctx, cfg, head, base.Spec.Ref, path)
 	result.Signals = signals
+	result.Bump = DetermineBump(signals)
 
-	current, err := ParseSemver(head.Spec.Version)
+	return finalizeVersion(cfg, result, base.Spec.Version, head.Spec.Version)
+}
+
+// fetchSignals calls the GitHub compare API and returns ChangeSignals.
+// On any error it logs a warning and returns an empty ChangeSignals (patch default).
+func fetchSignals(ctx context.Context, cfg Config, head skillSpecYAML, oldRef, specPath string) ChangeSignals {
+	if cfg.SkipAPICall || head.Spec.Repository == "" || oldRef == "" || head.Spec.Ref == "" {
+		return ChangeSignals{}
+	}
+	owner, repo, err := parseGitHubRepo(head.Spec.Repository)
 	if err != nil {
-		return BumpResult{}, fmt.Errorf("parsing current version %q: %w", head.Spec.Version, err)
+		return ChangeSignals{}
+	}
+	signals, err := computeSignals(ctx, cfg.Token, owner, repo, oldRef, head.Spec.Ref, head.Spec.Path)
+	if err != nil {
+		fmt.Printf("warning: GitHub compare API failed for %s: %v (defaulting to patch)\n", specPath, err)
+		return ChangeSignals{}
+	}
+	return signals
+}
+
+// finalizeVersion computes the expected version from bump type, compares it to
+// the current version on disk, and writes it if cfg.Write is set.
+func finalizeVersion(cfg Config, result BumpResult, oldVersion, currentVersion string) (BumpResult, error) {
+	current, err := ParseSemver(currentVersion)
+	if err != nil {
+		return BumpResult{}, fmt.Errorf("parsing current version %q: %w", currentVersion, err)
 	}
 
-	old, err := ParseSemver(base.Spec.Version)
+	old, err := ParseSemver(oldVersion)
 	if err != nil {
-		return BumpResult{}, fmt.Errorf("parsing base version %q: %w", base.Spec.Version, err)
+		return BumpResult{}, fmt.Errorf("parsing base version %q: %w", oldVersion, err)
 	}
 
-	expected := old.Bump(bump)
+	expected := old.Bump(result.Bump)
 	result.ExpectedVersion = expected.String()
 
-	if current.String() == expected.String() {
-		result.UpToDate = true
-		return result, nil
-	}
-
-	// Check if a higher bump was manually applied (acceptable).
-	if isHigherOrEqualBump(current, old, expected) {
+	if current.String() == expected.String() || isHigherOrEqualBump(current, expected) {
 		result.UpToDate = true
 		return result, nil
 	}
 
 	if cfg.Write {
-		if err := updateSpecVersion(path, expected.String()); err != nil {
+		if err := updateSpecVersion(result.SpecPath, expected.String()); err != nil {
 			return result, fmt.Errorf("writing version: %w", err)
 		}
 		result.CurrentVersion = expected.String()
@@ -142,22 +146,17 @@ func processOneSpec(ctx context.Context, cfg Config, path string) (BumpResult, e
 	return result, nil
 }
 
-// isHigherOrEqualBump returns true when the current version in the file is
-// already at least as high as the expected version, which means the human
-// reviewer applied a higher bump (e.g. minor when we suggested patch).
-func isHigherOrEqualBump(current, old, expected Semver) bool {
-	if current.Major > expected.Major {
-		return true
+// isHigherOrEqualBump returns true when current is already at or above
+// expected, meaning the reviewer applied a higher bump than the heuristic
+// suggested (e.g. minor when the tool would have picked patch).
+func isHigherOrEqualBump(current, expected Semver) bool {
+	if current.Major != expected.Major {
+		return current.Major > expected.Major
 	}
-	if current.Major == expected.Major && current.Minor > expected.Minor {
-		return true
+	if current.Minor != expected.Minor {
+		return current.Minor > expected.Minor
 	}
-	if current.Major == expected.Major && current.Minor == expected.Minor && current.Patch >= expected.Patch {
-		return true
-	}
-	// Also check that it's actually higher than old (not a downgrade).
-	_ = old
-	return false
+	return current.Patch >= expected.Patch
 }
 
 // CheckErrors returns a formatted error message listing all specs that are
@@ -178,7 +177,11 @@ func CheckErrors(results []BumpResult) error {
 	if len(bad) == 0 {
 		return nil
 	}
-	return fmt.Errorf("skill version check failed — run `go run ./cmd/skillversionbump --write` to fix:\n%s", strings.Join(bad, "\n"))
+	return fmt.Errorf(
+		"skill version check failed"+
+			" — run `go run ./cmd/skillversionbump --write` to fix:\n%s",
+		strings.Join(bad, "\n"),
+	)
 }
 
 func shortRef(ref string) string {

--- a/internal/skillversion/bump.go
+++ b/internal/skillversion/bump.go
@@ -3,6 +3,7 @@ package skillversion
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -20,6 +21,11 @@ type BumpResult struct {
 	Skipped bool
 	// UpToDate is true when CurrentVersion already matches ExpectedVersion.
 	UpToDate bool
+	// APIError is non-empty when the GitHub compare API call failed and the
+	// tool fell back to a default (patch) bump.  Reviewers should treat any
+	// non-empty APIError as a signal that the heuristic could not run and
+	// the suggested bump may be too low.
+	APIError string
 }
 
 // Config controls how ProcessSpecs behaves.
@@ -89,29 +95,44 @@ func processOneSpec(ctx context.Context, cfg Config, path string) (BumpResult, e
 		return result, nil
 	}
 
-	signals := fetchSignals(ctx, cfg, head, base.Spec.Ref, path)
+	// An empty spec.path would silently widen the heuristic's churn scope to
+	// the entire upstream repo, producing misleading minor bumps for unrelated
+	// drift.  Refuse rather than guess.
+	if strings.TrimSpace(head.Spec.Path) == "" {
+		return BumpResult{}, fmt.Errorf("spec.path is empty in %s; cannot scope upstream diff", path)
+	}
+
+	signals, apiErr := fetchSignals(ctx, cfg, head, base.Spec.Ref, path)
 	result.Signals = signals
 	result.Bump = DetermineBump(signals)
+	if apiErr != nil {
+		result.APIError = apiErr.Error()
+	}
 
 	return finalizeVersion(cfg, result, base.Spec.Version, head.Spec.Version)
 }
 
-// fetchSignals calls the GitHub compare API and returns ChangeSignals.
-// On any error it logs a warning and returns an empty ChangeSignals (patch default).
-func fetchSignals(ctx context.Context, cfg Config, head skillSpecYAML, oldRef, specPath string) ChangeSignals {
+// fetchSignals calls the GitHub compare API and returns ChangeSignals plus an
+// optional error.  When err is non-nil the returned ChangeSignals is the
+// zero value (which DetermineBump treats as patch) and the error is intended
+// to be surfaced via BumpResult.APIError so reviewers know the heuristic
+// could not run.  A warning is also printed to stderr for immediate visibility
+// in CI logs.
+func fetchSignals(ctx context.Context, cfg Config, head skillSpecYAML, oldRef, specPath string) (ChangeSignals, error) {
 	if cfg.SkipAPICall || head.Spec.Repository == "" || oldRef == "" || head.Spec.Ref == "" {
-		return ChangeSignals{}
+		return ChangeSignals{}, nil
 	}
 	owner, repo, err := parseGitHubRepo(head.Spec.Repository)
 	if err != nil {
-		return ChangeSignals{}
+		fmt.Fprintf(os.Stderr, "warning: cannot parse repository for %s: %v (defaulting to patch)\n", specPath, err)
+		return ChangeSignals{}, err
 	}
-	signals, err := computeSignals(ctx, cfg.Token, owner, repo, oldRef, head.Spec.Ref, head.Spec.Path)
+	signals, err := computeSignals(ctx, nil, cfg.Token, owner, repo, oldRef, head.Spec.Ref, head.Spec.Path)
 	if err != nil {
-		fmt.Printf("warning: GitHub compare API failed for %s: %v (defaulting to patch)\n", specPath, err)
-		return ChangeSignals{}
+		fmt.Fprintf(os.Stderr, "warning: GitHub compare API failed for %s: %v (defaulting to patch)\n", specPath, err)
+		return ChangeSignals{}, err
 	}
-	return signals
+	return signals, nil
 }
 
 // finalizeVersion computes the expected version from bump type, compares it to
@@ -160,19 +181,27 @@ func isHigherOrEqualBump(current, expected Semver) bool {
 }
 
 // CheckErrors returns a formatted error message listing all specs that are
-// not up to date, suitable for failing a CI step.
+// not up to date, suitable for failing a CI step.  When the heuristic could
+// not run because of a GitHub API failure (BumpResult.APIError set) that is
+// included in the message so reviewers know the suggested bump may be too
+// conservative.
 func CheckErrors(results []BumpResult) error {
 	var bad []string
 	for _, r := range results {
 		if r.Skipped || r.UpToDate {
 			continue
 		}
-		bad = append(bad, fmt.Sprintf(
-			"  %s: ref changed %s→%s but version %s needs to be at least %s (%s bump, signals: +/-%d lines, SKILL.md=%v, feat=%v)",
+		msg := fmt.Sprintf(
+			"  %s: ref changed %s→%s but version %s needs to be at least %s "+
+				"(%s bump, signals: +/-%d lines, SKILL.md=%v, feat=%v)",
 			r.SpecPath, shortRef(r.OldRef), shortRef(r.NewRef),
 			r.CurrentVersion, r.ExpectedVersion, r.Bump,
 			r.Signals.TotalChange, r.Signals.SkillMDTouched, r.Signals.FeatCommit,
-		))
+		)
+		if r.APIError != "" {
+			msg += fmt.Sprintf("\n      ⚠ heuristic ran without GitHub data: %s", r.APIError)
+		}
+		bad = append(bad, msg)
 	}
 	if len(bad) == 0 {
 		return nil

--- a/internal/skillversion/bump.go
+++ b/internal/skillversion/bump.go
@@ -1,0 +1,189 @@
+package skillversion
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// BumpResult records the outcome of evaluating one skill spec.yaml.
+type BumpResult struct {
+	SpecPath        string
+	OldRef          string
+	NewRef          string
+	OldVersion      string
+	CurrentVersion  string
+	ExpectedVersion string
+	Bump            BumpType
+	Signals         ChangeSignals
+	// Skipped is true when ref did not change (no action needed).
+	Skipped bool
+	// UpToDate is true when CurrentVersion already matches ExpectedVersion.
+	UpToDate bool
+}
+
+// Config controls how ProcessSpecs behaves.
+type Config struct {
+	// BaseRef is the git ref (SHA or branch) representing the merge base.
+	// Required unless SpecPaths are provided with explicit old refs.
+	BaseRef string
+	// Token is the GitHub API token used for the compare API.
+	// Falls back to unauthenticated if empty (rate-limited).
+	Token string
+	// Write, when true, updates spec.yaml files on disk instead of just
+	// checking them.
+	Write bool
+	// SkipAPICall disables the GitHub compare API call and always returns
+	// a patch bump.  Useful for offline testing.
+	SkipAPICall bool
+}
+
+// ProcessSpecs evaluates every spec path against the heuristic and either
+// checks that spec.version is correct (Config.Write == false) or updates it
+// (Config.Write == true).
+//
+// When specPaths is empty the function discovers changed specs automatically
+// using git diff against cfg.BaseRef.
+func ProcessSpecs(ctx context.Context, cfg Config, specPaths []string) ([]BumpResult, error) {
+	if len(specPaths) == 0 {
+		var err error
+		specPaths, err = changedSkillSpecs(cfg.BaseRef)
+		if err != nil {
+			return nil, fmt.Errorf("discovering changed specs: %w", err)
+		}
+	}
+
+	var results []BumpResult
+	for _, path := range specPaths {
+		result, err := processOneSpec(ctx, cfg, path)
+		if err != nil {
+			return results, fmt.Errorf("processing %s: %w", path, err)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func processOneSpec(ctx context.Context, cfg Config, path string) (BumpResult, error) {
+	head, err := readSpec(path)
+	if err != nil {
+		return BumpResult{}, err
+	}
+
+	base, err := readBaseSpec(cfg.BaseRef, path)
+	if err != nil {
+		// File may be new (no base); treat as needing a patch bump from 0.1.0.
+		// We skip it here — the PR author must set an initial version.
+		return BumpResult{SpecPath: path, Skipped: true}, nil
+	}
+
+	result := BumpResult{
+		SpecPath:       path,
+		OldRef:         base.Spec.Ref,
+		NewRef:         head.Spec.Ref,
+		OldVersion:     base.Spec.Version,
+		CurrentVersion: head.Spec.Version,
+	}
+
+	if base.Spec.Ref == head.Spec.Ref {
+		result.Skipped = true
+		return result, nil
+	}
+
+	// ref changed — compute expected version
+	var signals ChangeSignals
+	if !cfg.SkipAPICall && head.Spec.Repository != "" && base.Spec.Ref != "" && head.Spec.Ref != "" {
+		owner, repo, err := parseGitHubRepo(head.Spec.Repository)
+		if err == nil {
+			signals, err = computeSignals(ctx, cfg.Token, owner, repo, base.Spec.Ref, head.Spec.Ref, head.Spec.Path)
+			if err != nil {
+				// Non-fatal: fall back to patch if the API is unreachable.
+				fmt.Printf("warning: GitHub compare API failed for %s: %v (defaulting to patch)\n", path, err)
+			}
+		}
+	}
+
+	bump := DetermineBump(signals)
+	result.Bump = bump
+	result.Signals = signals
+
+	current, err := ParseSemver(head.Spec.Version)
+	if err != nil {
+		return BumpResult{}, fmt.Errorf("parsing current version %q: %w", head.Spec.Version, err)
+	}
+
+	old, err := ParseSemver(base.Spec.Version)
+	if err != nil {
+		return BumpResult{}, fmt.Errorf("parsing base version %q: %w", base.Spec.Version, err)
+	}
+
+	expected := old.Bump(bump)
+	result.ExpectedVersion = expected.String()
+
+	if current.String() == expected.String() {
+		result.UpToDate = true
+		return result, nil
+	}
+
+	// Check if a higher bump was manually applied (acceptable).
+	if isHigherOrEqualBump(current, old, expected) {
+		result.UpToDate = true
+		return result, nil
+	}
+
+	if cfg.Write {
+		if err := updateSpecVersion(path, expected.String()); err != nil {
+			return result, fmt.Errorf("writing version: %w", err)
+		}
+		result.CurrentVersion = expected.String()
+		result.UpToDate = true
+	}
+
+	return result, nil
+}
+
+// isHigherOrEqualBump returns true when the current version in the file is
+// already at least as high as the expected version, which means the human
+// reviewer applied a higher bump (e.g. minor when we suggested patch).
+func isHigherOrEqualBump(current, old, expected Semver) bool {
+	if current.Major > expected.Major {
+		return true
+	}
+	if current.Major == expected.Major && current.Minor > expected.Minor {
+		return true
+	}
+	if current.Major == expected.Major && current.Minor == expected.Minor && current.Patch >= expected.Patch {
+		return true
+	}
+	// Also check that it's actually higher than old (not a downgrade).
+	_ = old
+	return false
+}
+
+// CheckErrors returns a formatted error message listing all specs that are
+// not up to date, suitable for failing a CI step.
+func CheckErrors(results []BumpResult) error {
+	var bad []string
+	for _, r := range results {
+		if r.Skipped || r.UpToDate {
+			continue
+		}
+		bad = append(bad, fmt.Sprintf(
+			"  %s: ref changed %s→%s but version %s needs to be at least %s (%s bump, signals: +/-%d lines, SKILL.md=%v, feat=%v)",
+			r.SpecPath, shortRef(r.OldRef), shortRef(r.NewRef),
+			r.CurrentVersion, r.ExpectedVersion, r.Bump,
+			r.Signals.TotalChange, r.Signals.SkillMDTouched, r.Signals.FeatCommit,
+		))
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return fmt.Errorf("skill version check failed — run `go run ./cmd/skillversionbump --write` to fix:\n%s", strings.Join(bad, "\n"))
+}
+
+func shortRef(ref string) string {
+	if len(ref) > 8 {
+		return ref[:8]
+	}
+	return ref
+}

--- a/internal/skillversion/bump_test.go
+++ b/internal/skillversion/bump_test.go
@@ -1,0 +1,35 @@
+package skillversion
+
+import (
+	"testing"
+)
+
+func TestIsHigherOrEqualBump(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		current  Semver
+		expected Semver
+		want     bool
+	}{
+		{"equal versions", Semver{1, 2, 3}, Semver{1, 2, 3}, true},
+		{"current major higher", Semver{2, 0, 0}, Semver{1, 9, 9}, true},
+		{"current minor higher same major", Semver{1, 3, 0}, Semver{1, 2, 5}, true},
+		{"current patch higher same minor", Semver{1, 2, 4}, Semver{1, 2, 3}, true},
+		{"current patch lower same minor", Semver{1, 2, 2}, Semver{1, 2, 3}, false},
+		{"current minor lower same major", Semver{1, 1, 99}, Semver{1, 2, 0}, false},
+		{"current major lower", Semver{0, 9, 9}, Semver{1, 0, 0}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isHigherOrEqualBump(tt.current, tt.expected); got != tt.want {
+				t.Errorf("isHigherOrEqualBump(%v, %v) = %v, want %v",
+					tt.current, tt.expected, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/skillversion/github.go
+++ b/internal/skillversion/github.go
@@ -1,0 +1,130 @@
+package skillversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// compareFile represents a single file entry from the GitHub compare API.
+type compareFile struct {
+	Filename  string `json:"filename"`
+	Additions int    `json:"additions"`
+	Deletions int    `json:"deletions"`
+}
+
+// compareCommit represents a single commit entry from the GitHub compare API.
+type compareCommit struct {
+	Commit struct {
+		Message string `json:"message"`
+	} `json:"commit"`
+}
+
+// compareResponse is the subset of the GitHub compare API response we use.
+type compareResponse struct {
+	Files   []compareFile   `json:"files"`
+	Commits []compareCommit `json:"commits"`
+}
+
+// computeSignals calls the GitHub REST compare API for the given upstream
+// repository and ref range, then computes ChangeSignals filtered to the
+// skillPath subtree.
+//
+// owner and repo are the GitHub org/repo components (e.g. "huggingface",
+// "skills").  skillPath is the subdirectory prefix to filter files against
+// (empty string matches all files in the repo).
+//
+// apiToken may be empty to make unauthenticated requests (subject to a
+// much lower rate limit).
+func computeSignals(ctx context.Context, apiToken, owner, repo, oldRef, newRef, skillPath string) (ChangeSignals, error) {
+	cr, err := fetchCompare(ctx, apiToken, owner, repo, oldRef, newRef)
+	if err != nil {
+		return ChangeSignals{}, err
+	}
+
+	prefix := strings.TrimPrefix(skillPath, "/")
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	var signals ChangeSignals
+	for _, f := range cr.Files {
+		filename := f.Filename
+		if prefix != "" && !strings.HasPrefix(filename, prefix) {
+			// Check if the file exactly matches the prefix without the trailing slash
+			// (e.g. skill path is "skills/foo" and file is "skills/foo/SKILL.md")
+			if !strings.HasPrefix(filename, strings.TrimSuffix(prefix, "/")) {
+				continue
+			}
+		}
+		signals.TotalChange += f.Additions + f.Deletions
+		base := filename
+		if idx := strings.LastIndex(filename, "/"); idx >= 0 {
+			base = filename[idx+1:]
+		}
+		if strings.EqualFold(base, "SKILL.md") {
+			signals.SkillMDTouched = true
+		}
+	}
+
+	for _, c := range cr.Commits {
+		if IsFeatCommitMessage(c.Commit.Message) {
+			signals.FeatCommit = true
+			break
+		}
+	}
+
+	return signals, nil
+}
+
+// parseGitHubRepo extracts the "owner" and "repo" components from a GitHub
+// HTTPS URL such as "https://github.com/huggingface/skills".
+func parseGitHubRepo(repositoryURL string) (owner, repo string, err error) {
+	// Normalise: strip scheme and host to get the path
+	s := strings.TrimPrefix(repositoryURL, "https://github.com/")
+	s = strings.TrimPrefix(s, "http://github.com/")
+	s = strings.TrimSuffix(s, ".git")
+	parts := strings.SplitN(strings.TrimPrefix(s, "/"), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("cannot parse github owner/repo from URL %q", repositoryURL)
+	}
+	return parts[0], parts[1], nil
+}
+
+func fetchCompare(ctx context.Context, apiToken, owner, repo, oldRef, newRef string) (*compareResponse, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/compare/%s...%s", owner, repo, oldRef, newRef)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building GitHub compare request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+apiToken)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling GitHub compare API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub compare response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub compare API returned %d: %s", resp.StatusCode, body)
+	}
+
+	var cr compareResponse
+	if err := json.Unmarshal(body, &cr); err != nil {
+		return nil, fmt.Errorf("parsing GitHub compare response: %w", err)
+	}
+	return &cr, nil
+}

--- a/internal/skillversion/github.go
+++ b/internal/skillversion/github.go
@@ -7,7 +7,16 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
+
+// defaultHTTPClient is used when a caller does not supply its own client.
+// 30s is generous for the compare API which is single-shot per skill.
+var defaultHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// maxResponseBytes bounds the compare API response we will read into memory
+// (defense in depth — large diffs are rare but compare responses can grow).
+const maxResponseBytes = 10 * 1024 * 1024
 
 // compareFile represents a single file entry from the GitHub compare API.
 type compareFile struct {
@@ -38,9 +47,16 @@ type compareResponse struct {
 // (empty string matches all files in the repo).
 //
 // apiToken may be empty to make unauthenticated requests (subject to a
-// much lower rate limit).
-func computeSignals(ctx context.Context, apiToken, owner, repo, oldRef, newRef, skillPath string) (ChangeSignals, error) {
-	cr, err := fetchCompare(ctx, apiToken, owner, repo, oldRef, newRef)
+// much lower rate limit).  client may be nil to use the default client.
+func computeSignals(
+	ctx context.Context,
+	client *http.Client,
+	apiToken, owner, repo, oldRef, newRef, skillPath string,
+) (ChangeSignals, error) {
+	if client == nil {
+		client = defaultHTTPClient
+	}
+	cr, err := fetchCompare(ctx, client, apiToken, owner, repo, oldRef, newRef)
 	if err != nil {
 		return ChangeSignals{}, err
 	}
@@ -79,20 +95,37 @@ func computeSignals(ctx context.Context, apiToken, owner, repo, oldRef, newRef, 
 }
 
 // parseGitHubRepo extracts the "owner" and "repo" components from a GitHub
-// HTTPS URL such as "https://github.com/huggingface/skills".
+// HTTPS URL such as "https://github.com/huggingface/skills".  Non-GitHub
+// hosts are explicitly rejected — this tool only supports the GitHub compare
+// API, and silently mangling other hosts would lead to misleading bumps.
 func parseGitHubRepo(repositoryURL string) (owner, repo string, err error) {
-	// Normalise: strip scheme and host to get the path
-	s := strings.TrimPrefix(repositoryURL, "https://github.com/")
-	s = strings.TrimPrefix(s, "http://github.com/")
+	const ghPrefixHTTPS = "https://github.com/"
+	const ghPrefixHTTP = "http://github.com/"
+
+	var s string
+	switch {
+	case strings.HasPrefix(repositoryURL, ghPrefixHTTPS):
+		s = strings.TrimPrefix(repositoryURL, ghPrefixHTTPS)
+	case strings.HasPrefix(repositoryURL, ghPrefixHTTP):
+		s = strings.TrimPrefix(repositoryURL, ghPrefixHTTP)
+	default:
+		return "", "", fmt.Errorf("only github.com URLs are supported, got %q", repositoryURL)
+	}
+
 	s = strings.TrimSuffix(s, ".git")
-	parts := strings.SplitN(strings.TrimPrefix(s, "/"), "/", 2)
+	s = strings.TrimSuffix(s, "/")
+	parts := strings.SplitN(s, "/", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("cannot parse github owner/repo from URL %q", repositoryURL)
 	}
 	return parts[0], parts[1], nil
 }
 
-func fetchCompare(ctx context.Context, apiToken, owner, repo, oldRef, newRef string) (*compareResponse, error) {
+func fetchCompare(
+	ctx context.Context,
+	client *http.Client,
+	apiToken, owner, repo, oldRef, newRef string,
+) (*compareResponse, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/compare/%s...%s", owner, repo, oldRef, newRef)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -105,13 +138,13 @@ func fetchCompare(ctx context.Context, apiToken, owner, repo, oldRef, newRef str
 		req.Header.Set("Authorization", "Bearer "+apiToken)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("calling GitHub compare API: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	if err != nil {
 		return nil, fmt.Errorf("reading GitHub compare response: %w", err)
 	}

--- a/internal/skillversion/github.go
+++ b/internal/skillversion/github.go
@@ -53,12 +53,10 @@ func computeSignals(ctx context.Context, apiToken, owner, repo, oldRef, newRef, 
 	var signals ChangeSignals
 	for _, f := range cr.Files {
 		filename := f.Filename
+		// prefix already has a trailing slash, so this correctly scopes to the
+		// exact subtree and does not match siblings (e.g. "skills/foo-extra/").
 		if prefix != "" && !strings.HasPrefix(filename, prefix) {
-			// Check if the file exactly matches the prefix without the trailing slash
-			// (e.g. skill path is "skills/foo" and file is "skills/foo/SKILL.md")
-			if !strings.HasPrefix(filename, strings.TrimSuffix(prefix, "/")) {
-				continue
-			}
+			continue
 		}
 		signals.TotalChange += f.Additions + f.Deletions
 		base := filename

--- a/internal/skillversion/github_test.go
+++ b/internal/skillversion/github_test.go
@@ -12,6 +12,11 @@ import (
 func TestParseGitHubRepo(t *testing.T) {
 	t.Parallel()
 
+	const (
+		owner = "owner"
+		repo  = "repo"
+	)
+
 	tests := []struct {
 		name      string
 		input     string
@@ -20,9 +25,9 @@ func TestParseGitHubRepo(t *testing.T) {
 		wantErr   bool
 	}{
 		{"https url", "https://github.com/huggingface/skills", "huggingface", "skills", false},
-		{"https with .git suffix", "https://github.com/owner/repo.git", "owner", "repo", false},
-		{"https with trailing slash", "https://github.com/owner/repo/", "owner", "repo", false},
-		{"http url", "http://github.com/owner/repo", "owner", "repo", false},
+		{"https with .git suffix", "https://github.com/owner/repo.git", owner, repo, false},
+		{"https with trailing slash", "https://github.com/owner/repo/", owner, repo, false},
+		{"http url", "http://github.com/owner/repo", owner, repo, false},
 		{"trailing slash with no repo is rejected", "https://github.com/owner/", "", "", true},
 		{"missing repo", "https://github.com/owner", "", "", true},
 		{"non-github host rejected", "https://gitlab.com/owner/repo", "", "", true},

--- a/internal/skillversion/github_test.go
+++ b/internal/skillversion/github_test.go
@@ -1,0 +1,142 @@
+package skillversion
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseGitHubRepo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{"https url", "https://github.com/huggingface/skills", "huggingface", "skills", false},
+		{"https with .git suffix", "https://github.com/owner/repo.git", "owner", "repo", false},
+		{"https with trailing slash", "https://github.com/owner/repo/", "owner", "repo", false},
+		{"http url", "http://github.com/owner/repo", "owner", "repo", false},
+		{"trailing slash with no repo is rejected", "https://github.com/owner/", "", "", true},
+		{"missing repo", "https://github.com/owner", "", "", true},
+		{"non-github host rejected", "https://gitlab.com/owner/repo", "", "", true},
+		{"empty input", "", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			owner, repo, err := parseGitHubRepo(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseGitHubRepo(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && (owner != tt.wantOwner || repo != tt.wantRepo) {
+				t.Errorf("parseGitHubRepo(%q) = (%q, %q), want (%q, %q)",
+					tt.input, owner, repo, tt.wantOwner, tt.wantRepo)
+			}
+		})
+	}
+}
+
+// fakeCompareServer returns an httptest server that serves a canned
+// /repos/.../compare/... payload built from the given files and commits.
+func fakeCompareServer(t *testing.T, files []compareFile, commits []compareCommit) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/compare/") {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(compareResponse{Files: files, Commits: commits})
+	}))
+}
+
+// rewriteClient returns an *http.Client that rewrites all outgoing requests
+// to hit the test server, regardless of the URL the SUT constructs.
+func rewriteClient(targetURL string) *http.Client {
+	return &http.Client{Transport: rewriteTransport{target: targetURL}}
+}
+
+func TestComputeSignals_PrefixFilterScopesToSubtree(t *testing.T) {
+	t.Parallel()
+
+	// Files: one inside spec.path "skills/foo", one in a sibling
+	// "skills/foo-extra" that must NOT be counted.
+	files := []compareFile{
+		{Filename: "skills/foo/SKILL.md", Additions: 30, Deletions: 5},
+		{Filename: "skills/foo/scripts/run.sh", Additions: 10, Deletions: 0},
+		{Filename: "skills/foo-extra/SKILL.md", Additions: 999, Deletions: 999}, // sibling — must be ignored
+		{Filename: "README.md", Additions: 1, Deletions: 0},                     // out of subtree
+	}
+	srv := fakeCompareServer(t, files, nil)
+	defer srv.Close()
+
+	signals, err := computeSignals(
+		context.Background(),
+		rewriteClient(srv.URL),
+		"", "owner", "repo", "old", "new", "skills/foo",
+	)
+	if err != nil {
+		t.Fatalf("computeSignals: %v", err)
+	}
+
+	wantTotal := 30 + 5 + 10 + 0
+	if signals.TotalChange != wantTotal {
+		t.Errorf("TotalChange = %d, want %d (sibling subtree must not be counted)", signals.TotalChange, wantTotal)
+	}
+	if !signals.SkillMDTouched {
+		t.Errorf("SkillMDTouched = false, want true")
+	}
+	if signals.FeatCommit {
+		t.Errorf("FeatCommit = true, want false (no commits in fixture)")
+	}
+}
+
+func TestComputeSignals_FeatCommitDetected(t *testing.T) {
+	t.Parallel()
+
+	commits := []compareCommit{
+		{Commit: struct {
+			Message string `json:"message"`
+		}{Message: "fix: small typo"}},
+		{Commit: struct {
+			Message string `json:"message"`
+		}{Message: "feat(tools): add new tool"}},
+	}
+	srv := fakeCompareServer(t, nil, commits)
+	defer srv.Close()
+
+	signals, err := computeSignals(
+		context.Background(),
+		rewriteClient(srv.URL),
+		"", "owner", "repo", "old", "new", "skills/foo",
+	)
+	if err != nil {
+		t.Fatalf("computeSignals: %v", err)
+	}
+	if !signals.FeatCommit {
+		t.Errorf("FeatCommit = false, want true (one commit has feat: prefix)")
+	}
+}
+
+// rewriteTransport rewrites every outgoing request to use the host of `target`.
+type rewriteTransport struct {
+	target string
+}
+
+func (rt rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	parsed, err := http.NewRequest(req.Method, rt.target+req.URL.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	parsed.Header = req.Header
+	return http.DefaultTransport.RoundTrip(parsed)
+}

--- a/internal/skillversion/heuristic.go
+++ b/internal/skillversion/heuristic.go
@@ -27,7 +27,9 @@ var featCommitRe = regexp.MustCompile(`(?i)^(feat|feature)[\(:]`)
 type BumpType string
 
 const (
+	// BumpPatch means increment the patch version component (default).
 	BumpPatch BumpType = "patch"
+	// BumpMinor means increment the minor version component and reset patch to 0.
 	BumpMinor BumpType = "minor"
 )
 

--- a/internal/skillversion/heuristic.go
+++ b/internal/skillversion/heuristic.go
@@ -1,0 +1,70 @@
+// Package skillversion provides heuristics and tooling for automatically
+// bumping spec.version in skill spec.yaml files when spec.ref changes.
+// Dockyard owns semver for vendored skills because upstreams typically do not
+// publish per-skill version tags.
+package skillversion
+
+import "regexp"
+
+// Line-churn thresholds used by DetermineBump.  Adjust these constants to
+// re-tune the heuristic without touching any logic.
+const (
+	// MinorThresholdLines triggers a minor bump when the total lines added +
+	// deleted inside the skill subtree exceeds this value.
+	MinorThresholdLines = 120
+
+	// SkillMDMinorThresholdLines triggers a minor bump when SKILL.md itself
+	// is touched and total churn in the subtree exceeds this (lower threshold
+	// because SKILL.md edits signal user-visible changes).
+	SkillMDMinorThresholdLines = 40
+)
+
+// featCommitRe matches "feat:" / "feat(scope):" / "feature:" commit prefixes
+// (case-insensitive) that indicate user-facing additions.
+var featCommitRe = regexp.MustCompile(`(?i)^(feat|feature)[\(:]`)
+
+// BumpType represents the semver component to increment.
+type BumpType string
+
+const (
+	BumpPatch BumpType = "patch"
+	BumpMinor BumpType = "minor"
+)
+
+// ChangeSignals holds the raw measurements gathered from the upstream diff
+// that are fed into DetermineBump.
+type ChangeSignals struct {
+	// TotalChange is the sum of additions + deletions across all files in the
+	// skill subtree between the old and new ref.
+	TotalChange int
+	// SkillMDTouched is true when SKILL.md is among the changed files.
+	SkillMDTouched bool
+	// FeatCommit is true when at least one commit in range has a message that
+	// matches the feat/feature conventional-commit prefix.
+	FeatCommit bool
+}
+
+// DetermineBump returns the appropriate BumpType based on change signals.
+// The logic is intentionally simple and transparent:
+//   - minor if total churn >= MinorThresholdLines
+//   - minor if SKILL.md changed and churn >= SkillMDMinorThresholdLines
+//   - minor if any feat-style commit appears in range
+//   - patch otherwise
+func DetermineBump(signals ChangeSignals) BumpType {
+	if signals.TotalChange >= MinorThresholdLines {
+		return BumpMinor
+	}
+	if signals.SkillMDTouched && signals.TotalChange >= SkillMDMinorThresholdLines {
+		return BumpMinor
+	}
+	if signals.FeatCommit {
+		return BumpMinor
+	}
+	return BumpPatch
+}
+
+// IsFeatCommitMessage reports whether a raw commit message string matches the
+// feat/feature conventional-commit prefix.
+func IsFeatCommitMessage(msg string) bool {
+	return featCommitRe.MatchString(msg)
+}

--- a/internal/skillversion/heuristic_test.go
+++ b/internal/skillversion/heuristic_test.go
@@ -1,0 +1,85 @@
+package skillversion
+
+import (
+	"testing"
+)
+
+func TestDetermineBump(t *testing.T) {
+	tests := []struct {
+		name    string
+		signals ChangeSignals
+		want    BumpType
+	}{
+		{
+			name:    "small change is patch",
+			signals: ChangeSignals{TotalChange: 10},
+			want:    BumpPatch,
+		},
+		{
+			name:    "churn at threshold is minor",
+			signals: ChangeSignals{TotalChange: MinorThresholdLines},
+			want:    BumpMinor,
+		},
+		{
+			name:    "churn above threshold is minor",
+			signals: ChangeSignals{TotalChange: MinorThresholdLines + 50},
+			want:    BumpMinor,
+		},
+		{
+			name:    "SKILL.md touched below threshold is patch",
+			signals: ChangeSignals{TotalChange: SkillMDMinorThresholdLines - 1, SkillMDTouched: true},
+			want:    BumpPatch,
+		},
+		{
+			name:    "SKILL.md touched at threshold is minor",
+			signals: ChangeSignals{TotalChange: SkillMDMinorThresholdLines, SkillMDTouched: true},
+			want:    BumpMinor,
+		},
+		{
+			name:    "feat commit triggers minor regardless of churn",
+			signals: ChangeSignals{TotalChange: 5, FeatCommit: true},
+			want:    BumpMinor,
+		},
+		{
+			name:    "no signals defaults to patch",
+			signals: ChangeSignals{},
+			want:    BumpPatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetermineBump(tt.signals)
+			if got != tt.want {
+				t.Errorf("DetermineBump(%+v) = %q, want %q", tt.signals, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsFeatCommitMessage(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		{"feat: add new tool", true},
+		{"feat(scope): add new tool", true},
+		{"feature: something", true},
+		{"feature(ui): changes", true},
+		{"FEAT: uppercase", true},
+		{"fix: bug fix", false},
+		{"chore: maintenance", false},
+		{"docs: update readme", false},
+		{"refactor: clean up", false},
+		{"feat without colon or paren", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			got := IsFeatCommitMessage(tt.msg)
+			if got != tt.want {
+				t.Errorf("IsFeatCommitMessage(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/skillversion/heuristic_test.go
+++ b/internal/skillversion/heuristic_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestDetermineBump(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		signals ChangeSignals
@@ -49,6 +51,8 @@ func TestDetermineBump(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got := DetermineBump(tt.signals)
 			if got != tt.want {
 				t.Errorf("DetermineBump(%+v) = %q, want %q", tt.signals, got, tt.want)
@@ -58,6 +62,8 @@ func TestDetermineBump(t *testing.T) {
 }
 
 func TestIsFeatCommitMessage(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		msg  string
 		want bool
@@ -76,6 +82,8 @@ func TestIsFeatCommitMessage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.msg, func(t *testing.T) {
+			t.Parallel()
+
 			got := IsFeatCommitMessage(tt.msg)
 			if got != tt.want {
 				t.Errorf("IsFeatCommitMessage(%q) = %v, want %v", tt.msg, got, tt.want)

--- a/internal/skillversion/semver.go
+++ b/internal/skillversion/semver.go
@@ -1,0 +1,63 @@
+package skillversion
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Semver holds a parsed X.Y.Z version string.
+type Semver struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// ParseSemver parses a version string of the form "X.Y.Z" (leading "v" is
+// stripped if present).
+func ParseSemver(v string) (Semver, error) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return Semver{}, fmt.Errorf("invalid semver %q: expected X.Y.Z", v)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return Semver{}, fmt.Errorf("invalid semver major in %q: %w", v, err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return Semver{}, fmt.Errorf("invalid semver minor in %q: %w", v, err)
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return Semver{}, fmt.Errorf("invalid semver patch in %q: %w", v, err)
+	}
+	return Semver{Major: major, Minor: minor, Patch: patch}, nil
+}
+
+// String formats the semver as "X.Y.Z".
+func (s Semver) String() string {
+	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch)
+}
+
+// BumpPatch returns a new Semver with the patch component incremented.
+func (s Semver) BumpPatch() Semver {
+	return Semver{Major: s.Major, Minor: s.Minor, Patch: s.Patch + 1}
+}
+
+// BumpMinor returns a new Semver with the minor component incremented and
+// patch reset to 0.
+func (s Semver) BumpMinor() Semver {
+	return Semver{Major: s.Major, Minor: s.Minor + 1, Patch: 0}
+}
+
+// Bump returns a new Semver incremented according to t.
+func (s Semver) Bump(t BumpType) Semver {
+	switch t {
+	case BumpMinor:
+		return s.BumpMinor()
+	default:
+		return s.BumpPatch()
+	}
+}

--- a/internal/skillversion/semver.go
+++ b/internal/skillversion/semver.go
@@ -53,12 +53,10 @@ func (s Semver) BumpMinor() Semver {
 }
 
 // Bump returns a new Semver incremented according to t.
+// Unknown values fall through to a patch bump as the safest default.
 func (s Semver) Bump(t BumpType) Semver {
-	switch t {
-	case BumpMinor:
+	if t == BumpMinor {
 		return s.BumpMinor()
-	case BumpPatch:
-		return s.BumpPatch()
 	}
 	return s.BumpPatch()
 }

--- a/internal/skillversion/semver.go
+++ b/internal/skillversion/semver.go
@@ -57,7 +57,8 @@ func (s Semver) Bump(t BumpType) Semver {
 	switch t {
 	case BumpMinor:
 		return s.BumpMinor()
-	default:
+	case BumpPatch:
 		return s.BumpPatch()
 	}
+	return s.BumpPatch()
 }

--- a/internal/skillversion/semver_test.go
+++ b/internal/skillversion/semver_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestParseSemver(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input   string
 		want    Semver
@@ -22,6 +24,8 @@ func TestParseSemver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := ParseSemver(tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseSemver(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
@@ -34,6 +38,8 @@ func TestParseSemver(t *testing.T) {
 }
 
 func TestSemverBump(t *testing.T) {
+	t.Parallel()
+
 	base := Semver{0, 1, 0}
 
 	if got := base.BumpPatch(); got != (Semver{0, 1, 1}) {
@@ -51,6 +57,8 @@ func TestSemverBump(t *testing.T) {
 }
 
 func TestSemverString(t *testing.T) {
+	t.Parallel()
+
 	s := Semver{1, 2, 3}
 	if got := s.String(); got != "1.2.3" {
 		t.Errorf("String() = %q, want %q", got, "1.2.3")

--- a/internal/skillversion/semver_test.go
+++ b/internal/skillversion/semver_test.go
@@ -1,0 +1,58 @@
+package skillversion
+
+import (
+	"testing"
+)
+
+func TestParseSemver(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    Semver
+		wantErr bool
+	}{
+		{"1.2.3", Semver{1, 2, 3}, false},
+		{"0.1.0", Semver{0, 1, 0}, false},
+		{"v0.1.0", Semver{0, 1, 0}, false},
+		{"10.20.30", Semver{10, 20, 30}, false},
+		{"1.2", Semver{}, true},
+		{"1.2.3.4", Semver{}, true},
+		{"", Semver{}, true},
+		{"a.b.c", Semver{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSemver(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseSemver(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseSemver(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSemverBump(t *testing.T) {
+	base := Semver{0, 1, 0}
+
+	if got := base.BumpPatch(); got != (Semver{0, 1, 1}) {
+		t.Errorf("BumpPatch = %v, want 0.1.1", got)
+	}
+	if got := base.BumpMinor(); got != (Semver{0, 2, 0}) {
+		t.Errorf("BumpMinor = %v, want 0.2.0", got)
+	}
+	if got := base.Bump(BumpPatch); got != (Semver{0, 1, 1}) {
+		t.Errorf("Bump(patch) = %v, want 0.1.1", got)
+	}
+	if got := base.Bump(BumpMinor); got != (Semver{0, 2, 0}) {
+		t.Errorf("Bump(minor) = %v, want 0.2.0", got)
+	}
+}
+
+func TestSemverString(t *testing.T) {
+	s := Semver{1, 2, 3}
+	if got := s.String(); got != "1.2.3" {
+		t.Errorf("String() = %q, want %q", got, "1.2.3")
+	}
+}

--- a/internal/skillversion/specfile.go
+++ b/internal/skillversion/specfile.go
@@ -52,13 +52,22 @@ func readBaseSpec(baseRef, path string) (skillSpecYAML, error) {
 	return s, nil
 }
 
-// versionLineRe matches a `  version: "X.Y.Z"` line inside a spec.yaml.
-// It handles both quoted ("X.Y.Z") and bare (X.Y.Z) values.
+// specBlockStartRe matches the start of the top-level `spec:` block.
+var specBlockStartRe = regexp.MustCompile(`(?m)^spec:\s*$`)
+
+// nextTopLevelKeyRe matches the start of any other top-level YAML key (used to
+// locate the end of the spec block).
+var nextTopLevelKeyRe = regexp.MustCompile(`(?m)^\S`)
+
+// versionLineRe matches a `  version: "X.Y.Z"` line — used only inside the
+// already-isolated `spec:` block, so we don't risk rewriting unrelated fields.
 var versionLineRe = regexp.MustCompile(`(?m)^(\s+version:\s+)"?(\d+\.\d+\.\d+)"?`)
 
-// updateSpecVersion rewrites the `version:` field inside the spec block of
-// path on disk to newVersion, preserving all other content (including
-// comments).
+// updateSpecVersion rewrites the `version:` field inside the top-level `spec:`
+// block of path on disk to newVersion, preserving all other content
+// (including comments).  Only the first `version:` inside the spec block is
+// rewritten; nested or sibling `version:` lines elsewhere in the file are
+// untouched.
 func updateSpecVersion(path, newVersion string) error {
 	if err := validateSpecPath(path); err != nil {
 		return err
@@ -71,20 +80,46 @@ func updateSpecVersion(path, newVersion string) error {
 	}
 
 	original := string(data)
-	updated := versionLineRe.ReplaceAllStringFunc(original, func(match string) string {
-		// Preserve the indentation + key portion, replace only the value.
-		sub := versionLineRe.FindStringSubmatch(match)
-		if len(sub) < 3 {
-			return match
-		}
-		return sub[1] + `"` + newVersion + `"`
-	})
-
+	updated, err := replaceVersionInSpecBlock(original, newVersion)
+	if err != nil {
+		return fmt.Errorf("%s: %w", cleanPath, err)
+	}
 	if updated == original {
 		return fmt.Errorf("version field not found or unchanged in %s", cleanPath)
 	}
 
 	return os.WriteFile(cleanPath, []byte(updated), 0600) //#nosec G703 -- path validated above
+}
+
+// replaceVersionInSpecBlock locates the top-level `spec:` block in src and
+// rewrites the first `version:` line found inside it to newVersion.  Returns
+// the rewritten document.  Exposed (lowercase) for unit testing.
+func replaceVersionInSpecBlock(src, newVersion string) (string, error) {
+	specStart := specBlockStartRe.FindStringIndex(src)
+	if specStart == nil {
+		return "", fmt.Errorf("no top-level `spec:` block found")
+	}
+	bodyStart := specStart[1]
+
+	// Find where the spec block ends (next top-level key, or EOF).
+	rest := src[bodyStart:]
+	end := len(rest)
+	if nextKey := nextTopLevelKeyRe.FindStringIndex(rest); nextKey != nil {
+		end = nextKey[0]
+	}
+	specBody := rest[:end]
+
+	// Replace only the first `version:` line in the spec body.
+	loc := versionLineRe.FindStringSubmatchIndex(specBody)
+	if loc == nil {
+		return src, nil
+	}
+	prefix := specBody[:loc[2]]                                 // up to the indentation+key
+	keyPart := specBody[loc[2]:loc[3]]                          // "  version: "
+	suffix := specBody[loc[1]:]                                 // after the value
+	newBody := prefix + keyPart + `"` + newVersion + `"` + suffix
+
+	return src[:bodyStart] + newBody + rest[end:], nil
 }
 
 // validateSpecPath ensures path refers to a skill spec.yaml and contains no
@@ -101,9 +136,17 @@ func validateSpecPath(path string) error {
 }
 
 // changedSkillSpecs returns the paths of skills/*/spec.yaml files that differ
-// between baseRef and HEAD using `git diff --name-only`.
+// between baseRef and HEAD using `git diff --name-only baseRef...HEAD`.
+//
+// The triple-dot form (merge-base) matches what build-skills.yml uses and
+// avoids picking up unstaged local edits when the tool is run from a working
+// tree with uncommitted changes.
 func changedSkillSpecs(baseRef string) ([]string, error) {
-	cmd := exec.Command("git", "diff", "--name-only", baseRef, "--", "skills/*/spec.yaml") //#nosec G204
+	cmd := exec.Command( //#nosec G204 -- baseRef is from the CLI/CI env
+		"git", "diff", "--name-only",
+		baseRef+"...HEAD",
+		"--", "skills/*/spec.yaml",
+	)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/skillversion/specfile.go
+++ b/internal/skillversion/specfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -59,9 +60,14 @@ var versionLineRe = regexp.MustCompile(`(?m)^(\s+version:\s+)"?(\d+\.\d+\.\d+)"?
 // path on disk to newVersion, preserving all other content (including
 // comments).
 func updateSpecVersion(path, newVersion string) error {
-	data, err := os.ReadFile(path) //#nosec G304 -- path comes from the CLI caller
+	if err := validateSpecPath(path); err != nil {
+		return err
+	}
+
+	cleanPath := filepath.Clean(path)
+	data, err := os.ReadFile(cleanPath) //#nosec G304 -- path validated by validateSpecPath
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", path, err)
+		return fmt.Errorf("reading %s: %w", cleanPath, err)
 	}
 
 	original := string(data)
@@ -75,10 +81,23 @@ func updateSpecVersion(path, newVersion string) error {
 	})
 
 	if updated == original {
-		return fmt.Errorf("version field not found or unchanged in %s", path)
+		return fmt.Errorf("version field not found or unchanged in %s", cleanPath)
 	}
 
-	return os.WriteFile(path, []byte(updated), 0600)
+	return os.WriteFile(cleanPath, []byte(updated), 0600) //#nosec G703 -- path validated above
+}
+
+// validateSpecPath ensures path refers to a skill spec.yaml and contains no
+// directory traversal components.
+func validateSpecPath(path string) error {
+	clean := filepath.Clean(path)
+	if strings.Contains(clean, "..") {
+		return fmt.Errorf("refusing to write %q: path traversal detected", path)
+	}
+	if !strings.HasPrefix(clean, "skills/") || !strings.HasSuffix(clean, "/spec.yaml") {
+		return fmt.Errorf("refusing to write %q: must be a skills/*/spec.yaml path", path)
+	}
+	return nil
 }
 
 // changedSkillSpecs returns the paths of skills/*/spec.yaml files that differ

--- a/internal/skillversion/specfile.go
+++ b/internal/skillversion/specfile.go
@@ -1,0 +1,105 @@
+package skillversion
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// skillSpecYAML is a minimal representation of the fields we need from a
+// skills/*/spec.yaml file.  It deliberately does not import internal/skills to
+// keep this package independent.
+type skillSpecYAML struct {
+	Spec struct {
+		Repository string `yaml:"repository"`
+		Ref        string `yaml:"ref"`
+		Path       string `yaml:"path"`
+		Version    string `yaml:"version"`
+	} `yaml:"spec"`
+}
+
+// readSpec loads a skill spec.yaml from disk and returns the parsed fields.
+func readSpec(path string) (skillSpecYAML, error) {
+	data, err := os.ReadFile(path) //#nosec G304 -- path comes from the CLI caller
+	if err != nil {
+		return skillSpecYAML{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+	var s skillSpecYAML
+	if err := yaml.Unmarshal(data, &s); err != nil {
+		return skillSpecYAML{}, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// readBaseSpec reads a skill spec.yaml at a given git ref using `git show`.
+// baseRef is typically a commit SHA or "origin/main".
+func readBaseSpec(baseRef, path string) (skillSpecYAML, error) {
+	gitArg := fmt.Sprintf("%s:%s", baseRef, path)
+	out, err := exec.Command("git", "show", gitArg).Output() //#nosec G204 -- controlled args
+	if err != nil {
+		return skillSpecYAML{}, fmt.Errorf("git show %s: %w", gitArg, err)
+	}
+	var s skillSpecYAML
+	if err := yaml.Unmarshal(out, &s); err != nil {
+		return skillSpecYAML{}, fmt.Errorf("parsing base spec at %s: %w", gitArg, err)
+	}
+	return s, nil
+}
+
+// versionLineRe matches a `  version: "X.Y.Z"` line inside a spec.yaml.
+// It handles both quoted ("X.Y.Z") and bare (X.Y.Z) values.
+var versionLineRe = regexp.MustCompile(`(?m)^(\s+version:\s+)"?(\d+\.\d+\.\d+)"?`)
+
+// updateSpecVersion rewrites the `version:` field inside the spec block of
+// path on disk to newVersion, preserving all other content (including
+// comments).
+func updateSpecVersion(path, newVersion string) error {
+	data, err := os.ReadFile(path) //#nosec G304 -- path comes from the CLI caller
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	original := string(data)
+	updated := versionLineRe.ReplaceAllStringFunc(original, func(match string) string {
+		// Preserve the indentation + key portion, replace only the value.
+		sub := versionLineRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		return sub[1] + `"` + newVersion + `"`
+	})
+
+	if updated == original {
+		return fmt.Errorf("version field not found or unchanged in %s", path)
+	}
+
+	return os.WriteFile(path, []byte(updated), 0600)
+}
+
+// changedSkillSpecs returns the paths of skills/*/spec.yaml files that differ
+// between baseRef and HEAD using `git diff --name-only`.
+func changedSkillSpecs(baseRef string) ([]string, error) {
+	cmd := exec.Command("git", "diff", "--name-only", baseRef, "--", "skills/*/spec.yaml") //#nosec G204
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// git diff returns exit code 0 on success; any error here is real
+		return nil, fmt.Errorf("git diff: %w\nstderr: %s", err, stderr.String())
+	}
+
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths, nil
+}

--- a/internal/skillversion/specfile.go
+++ b/internal/skillversion/specfile.go
@@ -114,9 +114,12 @@ func replaceVersionInSpecBlock(src, newVersion string) (string, error) {
 	if loc == nil {
 		return src, nil
 	}
-	prefix := specBody[:loc[2]]                                 // up to the indentation+key
-	keyPart := specBody[loc[2]:loc[3]]                          // "  version: "
-	suffix := specBody[loc[1]:]                                 // after the value
+	// prefix = everything before the indentation; keyPart = "  version: ";
+	// suffix = everything after the original value.  We rewrite only the value
+	// (always quoted) and concatenate the three slices back together.
+	prefix := specBody[:loc[2]]
+	keyPart := specBody[loc[2]:loc[3]]
+	suffix := specBody[loc[1]:]
 	newBody := prefix + keyPart + `"` + newVersion + `"` + suffix
 
 	return src[:bodyStart] + newBody + rest[end:], nil

--- a/internal/skillversion/specfile_test.go
+++ b/internal/skillversion/specfile_test.go
@@ -1,0 +1,140 @@
+package skillversion
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateSpecPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"valid path", "skills/foo/spec.yaml", false},
+		{"valid path nested", "skills/some-name-with-dashes/spec.yaml", false},
+		{"path traversal rejected", "skills/../etc/spec.yaml", true},
+		{"wrong directory rejected", "npx/foo/spec.yaml", true},
+		{"wrong filename rejected", "skills/foo/other.yaml", true},
+		{"empty rejected", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateSpecPath(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateSpecPath(%q) err = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReplaceVersionInSpecBlock(t *testing.T) {
+	t.Parallel()
+
+	const original = `metadata:
+  name: foo
+  version: "9.9.9"  # this metadata version must NOT be touched
+spec:
+  repository: "https://github.com/owner/repo"
+  ref: "abc123"
+  path: "skills/foo"
+  version: "0.1.0"
+provenance:
+  version: "1.0.0"  # also must NOT be touched
+`
+
+	updated, err := replaceVersionInSpecBlock(original, "0.2.0")
+	if err != nil {
+		t.Fatalf("replaceVersionInSpecBlock: %v", err)
+	}
+
+	// The spec.version line must be rewritten.
+	if !strings.Contains(updated, `version: "0.2.0"`) {
+		t.Errorf("updated content missing new spec.version 0.2.0\n%s", updated)
+	}
+	// The metadata.version and provenance.version must be untouched.
+	if !strings.Contains(updated, `version: "9.9.9"`) {
+		t.Errorf("metadata.version was rewritten — should be untouched\n%s", updated)
+	}
+	if !strings.Contains(updated, `version: "1.0.0"`) {
+		t.Errorf("provenance.version was rewritten — should be untouched\n%s", updated)
+	}
+	// Comments must be preserved.
+	if !strings.Contains(updated, "must NOT be touched") {
+		t.Errorf("comments were stripped from the document\n%s", updated)
+	}
+}
+
+func TestReplaceVersionInSpecBlock_NoSpecBlock(t *testing.T) {
+	t.Parallel()
+
+	_, err := replaceVersionInSpecBlock("metadata:\n  name: foo\n", "0.2.0")
+	if err == nil {
+		t.Errorf("expected error when no spec: block is present, got nil")
+	}
+}
+
+func TestReplaceVersionInSpecBlock_NoVersionInSpec(t *testing.T) {
+	t.Parallel()
+
+	src := "spec:\n  repository: x\n  ref: y\n"
+	updated, err := replaceVersionInSpecBlock(src, "0.2.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated != src {
+		t.Errorf("expected source returned unchanged when no version line\nwant: %q\ngot:  %q", src, updated)
+	}
+}
+
+func TestUpdateSpecVersion_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	specDir := filepath.Join(dir, "skills", "test-skill")
+	if err := os.MkdirAll(specDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	specPath := filepath.Join(specDir, "spec.yaml")
+	const content = `metadata:
+  name: test-skill
+spec:
+  repository: "https://github.com/owner/repo"
+  ref: "abc123"
+  path: "skills/test-skill"
+  version: "0.1.0"
+`
+	if err := os.WriteFile(specPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// updateSpecVersion uses validateSpecPath which expects "skills/" prefix.
+	// We cd into the temp dir so the relative path matches.
+	prevWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(prevWd) }()
+
+	if err := updateSpecVersion("skills/test-skill/spec.yaml", "0.2.0"); err != nil {
+		t.Fatalf("updateSpecVersion: %v", err)
+	}
+
+	got, err := os.ReadFile("skills/test-skill/spec.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `version: "0.2.0"`) {
+		t.Errorf("file does not contain new version:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/skillversionbump` — a Go CLI that checks or updates `spec.version` in `skills/*/spec.yaml` files whenever `spec.ref` changes, enforcing Dockyard-owned semver (upstream repos like `huggingface/skills` do not publish per-skill version tags).
- Adds `internal/skillversion` package with the bump heuristic (patch by default; minor when line churn ≥ 120, `SKILL.md` is touched with churn ≥ 40, or a `feat:` commit appears in range), semver parsing/bumping, and GitHub compare API integration.
- Adds `.github/workflows/skill-version-check.yml` — runs `skillversionbump --check` on every PR touching `skills/**/spec.yaml`; a separate job auto-fixes and commits versions for Renovate/Dependabot bot PRs.
- Adds `docs/skill-versioning.md` with the full policy, heuristic thresholds, and local usage reference.

This resolves the silent OCI tag overwrite issue where Renovate PRs (e.g. #615) bumped `spec.ref` but left `spec.version` unchanged, causing the build to republish different content under the same image tag.

## Test plan

- [x] CI `skill-version-check` passes on this PR (no skill specs were changed so all specs are skipped).
- [x] `go test ./internal/skillversion/...` passes (20 unit tests covering heuristic, semver, and IsFeatCommitMessage).
- [x] Manual: `go run ./cmd/skillversionbump --base origin/main --skip-api` exits 0 with all specs skipped (no ref changes in this PR).
- [ ] Open a follow-up test PR that bumps one `spec.ref` without touching `spec.version` and confirm `skill-version-check` fails.