### PR TITLE
feat(skills): add 5 skills from kepano/obsidian-skills

### DIFF
--- a/skills/defuddle/spec.yaml
+++ b/skills/defuddle/spec.yaml
@@ -1,0 +1,23 @@
+# Kepano defuddle Skill
+# Extract clean markdown content from web pages using Defuddle CLI, removing clutter to save tokens.
+# Source: https://github.com/kepano/obsidian-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/defuddle:0.1.0
+
+metadata:
+  name: defuddle
+  description: "Extract clean markdown content from web pages using Defuddle CLI, removing clutter and navigation to save tokens. Use instead of WebFetch when the user provides a URL to read or analyze, for online documentation, articles, blog posts, or any standard web page. Do NOT use for URLs ending in .md — those are already markdown, use WebFetch directly."
+
+spec:
+  repository: "https://github.com/kepano/obsidian-skills"
+  ref: "fa1e131a014576ff8f8919f191a7ca8d8fded39b"  # main as of 2026-04-02
+  path: "skills/defuddle"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/kepano/obsidian-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "kepano/obsidian-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/json-canvas/spec.yaml
+++ b/skills/json-canvas/spec.yaml
@@ -1,0 +1,23 @@
+# Kepano json-canvas Skill
+# Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections.
+# Source: https://github.com/kepano/obsidian-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/json-canvas:0.1.0
+
+metadata:
+  name: json-canvas
+  description: "Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas files, creating visual canvases, mind maps, flowcharts, or when the user mentions Canvas files in Obsidian."
+
+spec:
+  repository: "https://github.com/kepano/obsidian-skills"
+  ref: "fa1e131a014576ff8f8919f191a7ca8d8fded39b"  # main as of 2026-04-02
+  path: "skills/json-canvas"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/kepano/obsidian-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "kepano/obsidian-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/obsidian-bases/spec.yaml
+++ b/skills/obsidian-bases/spec.yaml
@@ -1,0 +1,23 @@
+# Kepano obsidian-bases Skill
+# Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries.
+# Source: https://github.com/kepano/obsidian-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/obsidian-bases:0.1.0
+
+metadata:
+  name: obsidian-bases
+  description: "Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .base files, creating database-like views of notes, or when the user mentions Bases, table views, card views, filters, or formulas in Obsidian."
+
+spec:
+  repository: "https://github.com/kepano/obsidian-skills"
+  ref: "fa1e131a014576ff8f8919f191a7ca8d8fded39b"  # main as of 2026-04-02
+  path: "skills/obsidian-bases"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/kepano/obsidian-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "kepano/obsidian-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/obsidian-cli/spec.yaml
+++ b/skills/obsidian-cli/spec.yaml
@@ -1,0 +1,23 @@
+# Kepano obsidian-cli Skill
+# Interact with Obsidian vaults using the Obsidian CLI for notes, tasks, properties, and plugin/theme dev.
+# Source: https://github.com/kepano/obsidian-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/obsidian-cli:0.1.0
+
+metadata:
+  name: obsidian-cli
+  description: "Interact with Obsidian vaults using the Obsidian CLI to read, create, search, and manage notes, tasks, properties, and more. Also supports plugin and theme development with commands to reload plugins, run JavaScript, capture errors, take screenshots, and inspect the DOM. Use when the user asks to interact with their Obsidian vault, manage notes, search vault content, perform vault operations from the command line, or develop and debug Obsidian plugins and themes."
+
+spec:
+  repository: "https://github.com/kepano/obsidian-skills"
+  ref: "fa1e131a014576ff8f8919f191a7ca8d8fded39b"  # main as of 2026-04-02
+  path: "skills/obsidian-cli"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/kepano/obsidian-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "kepano/obsidian-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/obsidian-markdown/spec.yaml
+++ b/skills/obsidian-markdown/spec.yaml
@@ -1,0 +1,23 @@
+# Kepano obsidian-markdown Skill
+# Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties.
+# Source: https://github.com/kepano/obsidian-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/obsidian-markdown:0.1.0
+
+metadata:
+  name: obsidian-markdown
+  description: "Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific syntax. Use when working with .md files in Obsidian, or when the user mentions wikilinks, callouts, frontmatter, tags, embeds, or Obsidian notes."
+
+spec:
+  repository: "https://github.com/kepano/obsidian-skills"
+  ref: "fa1e131a014576ff8f8919f191a7ca8d8fded39b"  # main as of 2026-04-02
+  path: "skills/obsidian-markdown"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/kepano/obsidian-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "kepano/obsidian-skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Add packaging specs for all 5 skills from [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) (MIT-licensed), pinned to commit `fa1e131a014576ff8f8919f191a7ca8d8fded39b` (`main` as of 2026-04-02) at dockyard version `0.1.0`. Each spec follows the existing template (e.g. [`skills/skill-writer/spec.yaml`](https://github.com/stacklok/dockyard/blob/main/skills/skill-writer/spec.yaml)).

### Skills added

- **`obsidian-markdown`** — create/edit Obsidian Flavored Markdown (wikilinks, embeds, callouts, properties, tags)
- **`obsidian-bases`** — create/edit Obsidian Bases (`.base` files): views, filters, formulas, summaries
- **`json-canvas`** — create/edit `.canvas` files per JSON Canvas Spec 1.0 (nodes, edges, groups)
- **`obsidian-cli`** — interact with Obsidian vaults via the `obsidian` CLI; also plugin/theme dev (reload, eval, dev:errors, dev:screenshot)
- **`defuddle`** — extract clean markdown from web pages via the Defuddle CLI to save tokens vs. raw WebFetch

### Allowlist

Each spec allowlists `MANIFEST_MISSING_LICENSE` with the same reason used for the existing mattpocock and sentry skills: `kepano/obsidian-skills` carries its MIT license at the repository root rather than embedding an SPDX identifier in per-skill `SKILL.md` frontmatter.

### Renovate

No config changes required: the existing `^skills/.*/spec\.yaml$` regex manager in [`renovate.json`](https://github.com/stacklok/dockyard/blob/main/renovate.json) auto-tracks digest bumps for these new specs, and the automated semver bump from #619 will apply.

## Test plan

- [x] Local validation via `dockhand validate-skill --config skills/<name>/spec.yaml` for all 5 new specs (`Status: VALID` across the board, file counts match upstream: 4 / 2 / 2 / 1 / 1).
- [ ] CI `validate-skills` matrix passes for the 5 new configs.
- [ ] CI `skill-security-scan` passes (only the allowlisted `MANIFEST_MISSING_LICENSE` finding expected).
- [ ] CI `build-skill-artifacts` (dry-run on PR) succeeds.