### PR TITLE
ci(renovate): batch dependency PRs to a weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "schedule:weekly"
   ],
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],


### PR DESCRIPTION
## Summary
- `renovate.json` had no `schedule`, so Renovate opened PRs whenever its App fired — often several per day (e.g., 4 PRs on 2026-05-08 across go.mod, npm, and digest pin updates).
- Added the `schedule:weekly` preset, which constrains Renovate to "before 3am on Monday" for all managers (go.mod, GitHub Actions, and the custom npx/uvx/go/skills managers).
- Security/vulnerability PRs still bypass the schedule per Renovate defaults, so this only batches routine version bumps.

## Test plan
- [ ] Confirm the next Renovate run waits until Monday before 3am UTC (no new dep PRs opened in between).
- [ ] If a different window is preferred (e.g., Sunday evening), swap the preset for an explicit `"schedule": ["before 6am on monday"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)