### PR TITLE
fix(skills): update clickhouse/agent-skills to 544384f, allowlist FP

### DIFF
--- a/skills/chdb-datastore/spec.yaml
+++ b/skills/chdb-datastore/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/chdb-datastore"
   version: "0.1.1"
 

--- a/skills/chdb-datastore/spec.yaml
+++ b/skills/chdb-datastore/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/chdb-datastore"
-  version: "0.1.1"
+  version: "0.1.2"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/chdb-sql/spec.yaml
+++ b/skills/chdb-sql/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/chdb-sql"
-  version: "0.1.1"
+  version: "0.1.2"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/chdb-sql/spec.yaml
+++ b/skills/chdb-sql/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/chdb-sql"
   version: "0.1.1"
 

--- a/skills/clickhouse-architecture-advisor/spec.yaml
+++ b/skills/clickhouse-architecture-advisor/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhouse-architecture-advisor"
   version: "0.1.1"
 

--- a/skills/clickhouse-architecture-advisor/spec.yaml
+++ b/skills/clickhouse-architecture-advisor/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhouse-architecture-advisor"
-  version: "0.1.1"
+  version: "0.1.2"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/clickhouse-best-practices/spec.yaml
+++ b/skills/clickhouse-best-practices/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhouse-best-practices"
-  version: "0.1.1"
+  version: "0.1.2"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/clickhouse-best-practices/spec.yaml
+++ b/skills/clickhouse-best-practices/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhouse-best-practices"
   version: "0.1.1"
 

--- a/skills/clickhousectl-cloud-deploy/spec.yaml
+++ b/skills/clickhousectl-cloud-deploy/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhousectl-cloud-deploy"
   version: "0.2.0"
 

--- a/skills/clickhousectl-cloud-deploy/spec.yaml
+++ b/skills/clickhousectl-cloud-deploy/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhousectl-cloud-deploy"
-  version: "0.2.0"
+  version: "0.2.1"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/clickhousectl-cloud-deploy/spec.yaml
+++ b/skills/clickhousectl-cloud-deploy/spec.yaml
@@ -28,3 +28,9 @@ security:
     # in SKILL.md docs. Both are benign documentation, not executable threats.
     - rule_id: ATR_2026_00111
       reason: "FP: cisco-ai-skill-scanner matched the documented `curl ... | sh` ClickHouse CLI installer and an `openssl rand` random-password example in docs; no executable threat. ClickHouse/agent-skills @f12bbf0fe55147a396ed391976c459276874fb33."
+    # FP: ATR_2026_00012 pattern-matches `$PASSWORD` in the Step 6 dedicated-user
+    # walkthrough (SKILL.md), where a random password is generated via
+    # `openssl rand -base64 32` and referenced when creating the user. Documentation
+    # of a secure credential-generation practice, not a leaked/hardcoded secret.
+    - rule_id: ATR_2026_00012
+      reason: "FP: cisco-ai-skill-scanner matched the `$PASSWORD` shell variable in the documented Step 6 example (generate via `openssl rand -base64 32`, use to create a scoped ClickHouse user). No hardcoded or leaked credential; the value is randomly generated at runtime."

--- a/skills/clickhousectl-local-dev/spec.yaml
+++ b/skills/clickhousectl-local-dev/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/ClickHouse/agent-skills"
   ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhousectl-local-dev"
-  version: "0.1.1"
+  version: "0.1.2"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/clickhousectl-local-dev/spec.yaml
+++ b/skills/clickhousectl-local-dev/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "f12bbf0fe55147a396ed391976c459276874fb33"  # main as of 2026-04-20
+  ref: "544384f4fab1d6ed59f16a354d1c68296dfa6007"  # main as of 2026-04-20
   path: "skills/clickhousectl-local-dev"
   version: "0.1.1"
 


### PR DESCRIPTION
## Summary
- Supersedes #673. Carries the same digest/version bump renovate proposed (`08a842e`-era → `544384f4fab1d6ed59f16a354d1c68296dfa6007`) plus a fix for the resulting scan failure.
- `skill-security-scan` on `skills/clickhousectl-cloud-deploy` blocked on `ATR_2026_00012` (HIGH): the scanner pattern-matched the `$PASSWORD` shell variable in SKILL.md's Step 6 dedicated-user walkthrough. Confirmed against the actual upstream doc — it's `PASSWORD=$(openssl rand -base64 32)`, a randomly-generated credential documented for creating a scoped ClickHouse user, not a hardcoded/leaked secret. Added to `security.allowed_issues` with rationale.

## Test plan
- [x] Built `dockhand` locally, ran `validate-skill` against `skills/clickhousectl-cloud-deploy/spec.yaml` — `Status: VALID`
- [ ] CI green on this PR (validate-skills, skill-security-scan, build-skill-artifacts)
- [ ] Close #673 once this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>