### PR TITLE
fix(mcp): update pagerduty-mcp to v1.0.0, add mock_env for scan

### DIFF
--- a/uvx/pagerduty-mcp/spec.yaml
+++ b/uvx/pagerduty-mcp/spec.yaml
@@ -18,6 +18,14 @@ provenance:
   repository_ref: "refs/heads/main"  # Using main branch as the primary development branch
 
 security:
+  # Mock env vars allow security scanning without real credentials. pagerduty-mcp
+  # v1 creates the PagerDuty client eagerly at startup and raises RuntimeError
+  # without an API key, which previously prevented the scanner from connecting
+  # to the server at all.
+  mock_env:
+    - name: PAGERDUTY_USER_API_KEY
+      value: "mock-pagerduty-api-key-for-scanning"
+      description: "PagerDuty API key — mock value for security scanning"
   allowed_issues:
     - code: "AITech-8.2"
       reason: "Data leak risk acceptable - incident management requires sharing operational data with responders and creating public status updates. Write operations are disabled by default, requiring explicit opt-in with --enable-write-tools flag."

--- a/uvx/pagerduty-mcp/spec.yaml
+++ b/uvx/pagerduty-mcp/spec.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   package: "pagerduty-mcp"
-  version: "0.17.0"
+  version: "1.0.0"
 
 provenance:
   repository_uri: "https://github.com/PagerDuty/pagerduty-mcp-server"


### PR DESCRIPTION
## Summary
- Supersedes #731. Carries the same version bump renovate proposed (pagerduty-mcp 0.17.0 -> 1.0.0) plus a fix for the resulting scan failure.
- `mcp-security-scan` couldn't even launch the server: v1 creates the PagerDuty client eagerly at startup (`ApplicationContextStrategy.__init__` -> `create_pd_client()`) and raises `RuntimeError: An API key is required to call the PagerDuty API` without `PAGERDUTY_USER_API_KEY` set, so the scanner's stdio connection died immediately. This is not a security finding — the scan harness needs credentials to launch the server in the first place.
- Added a `security.mock_env` entry (existing mechanism, already used by pinecone-mcp/launchdarkly-mcp-server/etc.) with a dummy `PAGERDUTY_USER_API_KEY` so the scanner can connect and actually enumerate tools.

## Test plan
- [x] Verified `scripts/mcp-scan/generate_mcp_config.py` picks up the new `mock_env` correctly
- [ ] CI green on this PR (mcp-security-scan, build-containers)
- [ ] Close #731 once this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>