### PR TITLE
fix(skills): update vercel-labs/agent-skills to f8a72b9, allowlist FP

### DIFF
--- a/skills/vercel-cli-with-tokens/spec.yaml
+++ b/skills/vercel-cli-with-tokens/spec.yaml
@@ -10,7 +10,7 @@ metadata:
 
 spec:
   repository: "https://github.com/vercel-labs/agent-skills"
-  ref: "b9c8ee0643d87d3c5a953d1e22382ff2ead39229"  # main as of 2026-04-30
+  ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/vercel-cli-with-tokens"
   version: "0.1.0"
 

--- a/skills/vercel-cli-with-tokens/spec.yaml
+++ b/skills/vercel-cli-with-tokens/spec.yaml
@@ -22,3 +22,9 @@ security:
   allowed_issues:
     - rule_id: MANIFEST_MISSING_LICENSE
       reason: "vercel-labs/agent-skills declares MIT in README.md; upstream does not include a LICENSE file at the repository root, and this skill's SKILL.md frontmatter does not embed an SPDX license identifier."
+    # FP: ATR_2026_00115 pattern-matches `printenv | grep -i vercel` in SKILL.md's
+    # "Token not found" troubleshooting section — a read-only local environment
+    # lookup (plus grepping a local .env file) to help diagnose missing config,
+    # not a credential exfiltration vector.
+    - rule_id: ATR_2026_00115
+      reason: "FP: cisco-ai-skill-scanner matched 'printenv | grep -i vercel' in SKILL.md's Troubleshooting > Token not found section; a read-only local env/'.env' lookup for diagnosing missing config, no exfiltration."

--- a/skills/vercel-cli-with-tokens/spec.yaml
+++ b/skills/vercel-cli-with-tokens/spec.yaml
@@ -12,7 +12,7 @@ spec:
   repository: "https://github.com/vercel-labs/agent-skills"
   ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/vercel-cli-with-tokens"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/vercel-labs/agent-skills"

--- a/skills/vercel-composition-patterns/spec.yaml
+++ b/skills/vercel-composition-patterns/spec.yaml
@@ -10,7 +10,7 @@ metadata:
 
 spec:
   repository: "https://github.com/vercel-labs/agent-skills"
-  ref: "b9c8ee0643d87d3c5a953d1e22382ff2ead39229"  # main as of 2026-04-30
+  ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/composition-patterns"
   version: "0.1.0"
 

--- a/skills/vercel-composition-patterns/spec.yaml
+++ b/skills/vercel-composition-patterns/spec.yaml
@@ -12,7 +12,7 @@ spec:
   repository: "https://github.com/vercel-labs/agent-skills"
   ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/composition-patterns"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/vercel-labs/agent-skills"

--- a/skills/vercel-react-best-practices/spec.yaml
+++ b/skills/vercel-react-best-practices/spec.yaml
@@ -12,7 +12,7 @@ spec:
   repository: "https://github.com/vercel-labs/agent-skills"
   ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-best-practices"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/vercel-labs/agent-skills"

--- a/skills/vercel-react-best-practices/spec.yaml
+++ b/skills/vercel-react-best-practices/spec.yaml
@@ -10,7 +10,7 @@ metadata:
 
 spec:
   repository: "https://github.com/vercel-labs/agent-skills"
-  ref: "b9c8ee0643d87d3c5a953d1e22382ff2ead39229"  # main as of 2026-04-30
+  ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-best-practices"
   version: "0.1.0"
 

--- a/skills/vercel-react-native-skills/spec.yaml
+++ b/skills/vercel-react-native-skills/spec.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   repository: "https://github.com/vercel-labs/agent-skills"
-  ref: "b9c8ee0643d87d3c5a953d1e22382ff2ead39229"  # main as of 2026-04-30
+  ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-native-skills"
   version: "0.1.0"
 

--- a/skills/vercel-react-native-skills/spec.yaml
+++ b/skills/vercel-react-native-skills/spec.yaml
@@ -13,7 +13,7 @@ spec:
   repository: "https://github.com/vercel-labs/agent-skills"
   ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-native-skills"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/vercel-labs/agent-skills"

--- a/skills/vercel-react-view-transitions/spec.yaml
+++ b/skills/vercel-react-view-transitions/spec.yaml
@@ -13,7 +13,7 @@ spec:
   repository: "https://github.com/vercel-labs/agent-skills"
   ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-view-transitions"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/vercel-labs/agent-skills"

--- a/skills/vercel-react-view-transitions/spec.yaml
+++ b/skills/vercel-react-view-transitions/spec.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   repository: "https://github.com/vercel-labs/agent-skills"
-  ref: "b9c8ee0643d87d3c5a953d1e22382ff2ead39229"  # main as of 2026-04-30
+  ref: "f8a72b9603728bb92a217a879b7e62e43ad76c81"  # main as of 2026-04-30
   path: "skills/react-view-transitions"
   version: "0.1.0"
 


### PR DESCRIPTION
## Summary
- Supersedes #700. Carries the same digest/version bump renovate proposed plus a fix for the resulting scan failure.
- `skill-security-scan` on `skills/vercel-cli-with-tokens` blocked on `ATR_2026_00115` (CRITICAL): the scanner pattern-matched `printenv | grep -i vercel` in SKILL.md's "Token not found" troubleshooting section. Confirmed against upstream f8a72b9 — it's a read-only local environment/`.env` lookup to help diagnose missing config, not a credential exfiltration vector. Added to `security.allowed_issues`.

## Test plan
- [x] Built `dockhand` locally, ran `validate-skill` against `skills/vercel-cli-with-tokens/spec.yaml` — `Status: VALID`
- [ ] CI green on this PR
- [ ] Close #700 once this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>