### PR TITLE
fix(skills): update mongodb/agent-skills to be846b4, fix path move

### DIFF
--- a/skills/atlas-stream-processing/spec.yaml
+++ b/skills/atlas-stream-processing/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/atlas-stream-processing"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/atlas-stream-processing/spec.yaml
+++ b/skills/atlas-stream-processing/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/atlas-stream-processing"
   version: "0.1.1"
 

--- a/skills/atlas-stream-processing/spec.yaml
+++ b/skills/atlas-stream-processing/spec.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
-  path: "skills/atlas-stream-processing"
+  path: "skills/mongodb-atlas-stream-processing"
   version: "0.2.0"
 
 provenance:

--- a/skills/mongodb-connection/spec.yaml
+++ b/skills/mongodb-connection/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-connection"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/mongodb-connection/spec.yaml
+++ b/skills/mongodb-connection/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-connection"
   version: "0.1.1"
 

--- a/skills/mongodb-mcp-setup/spec.yaml
+++ b/skills/mongodb-mcp-setup/spec.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-mcp-setup"
   version: "0.1.1"
 

--- a/skills/mongodb-mcp-setup/spec.yaml
+++ b/skills/mongodb-mcp-setup/spec.yaml
@@ -13,7 +13,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-mcp-setup"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/mongodb-natural-language-querying/spec.yaml
+++ b/skills/mongodb-natural-language-querying/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-natural-language-querying"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/mongodb-natural-language-querying/spec.yaml
+++ b/skills/mongodb-natural-language-querying/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-natural-language-querying"
   version: "0.1.1"
 

--- a/skills/mongodb-query-optimizer/spec.yaml
+++ b/skills/mongodb-query-optimizer/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-query-optimizer"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/mongodb-query-optimizer/spec.yaml
+++ b/skills/mongodb-query-optimizer/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-query-optimizer"
   version: "0.1.1"
 

--- a/skills/mongodb-schema-design/spec.yaml
+++ b/skills/mongodb-schema-design/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-schema-design"
   version: "0.1.1"
 

--- a/skills/mongodb-schema-design/spec.yaml
+++ b/skills/mongodb-schema-design/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-schema-design"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"

--- a/skills/mongodb-search-and-ai/spec.yaml
+++ b/skills/mongodb-search-and-ai/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/mongodb/agent-skills"
-  ref: "5cbde1c81a8c5e18de0952e52ec90808be11283f"  # main as of 2026-04-07
+  ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-search-and-ai"
   version: "0.1.1"
 

--- a/skills/mongodb-search-and-ai/spec.yaml
+++ b/skills/mongodb-search-and-ai/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/mongodb/agent-skills"
   ref: "be846b4deb482c22a5fb4d133d6c1e6c4a32eb08"  # main as of 2026-04-07
   path: "skills/mongodb-search-and-ai"
-  version: "0.1.1"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mongodb/agent-skills"


### PR DESCRIPTION
## Summary
- Supersedes #692. Carries the same digest/version bump renovate proposed for all 7 mongodb skills, plus a path fix for the one that broke.
- `atlas-stream-processing`: upstream moved this skill from `skills/atlas-stream-processing` to `skills/mongodb-atlas-stream-processing` at the new ref — fixed `spec.path` to match.
- **Known remaining issue (not fixed here):** `mongodb-schema-design`'s `skill-security-scan` still fails due to a scanner meta-analyzer JSON-parse bug (406 raw findings retained after the false-positive filter crashed) — this is a scanner tooling reliability issue, not a dockyard content problem, and isn't practically fixable by hand-allowlisting hundreds of findings. Tracked separately; will need the scanner tooling fixed or a manual re-run to get lucky on the non-deterministic pass.

## Test plan
- [x] Built `dockhand` locally, ran `validate-skill` against `skills/atlas-stream-processing/spec.yaml` — `Status: VALID`
- [ ] CI on this PR: expect all skills except `mongodb-schema-design` to go green
- [ ] Close #692 once this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>