### PR TITLE
fix(skills): update trailofbits/skills to cfe5d7b, fix zeroize-audit

### DIFF
--- a/skills/agentic-actions-auditor/spec.yaml
+++ b/skills/agentic-actions-auditor/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/agentic-actions-auditor/skills/agentic-actions-auditor"
   version: "0.1.0"
 

--- a/skills/agentic-actions-auditor/spec.yaml
+++ b/skills/agentic-actions-auditor/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/agentic-actions-auditor/skills/agentic-actions-auditor"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/codeql/spec.yaml
+++ b/skills/codeql/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/codeql"
   version: "0.1.0"
 

--- a/skills/codeql/spec.yaml
+++ b/skills/codeql/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/codeql"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/constant-time-analysis/spec.yaml
+++ b/skills/constant-time-analysis/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/constant-time-analysis/skills/constant-time-analysis"
   version: "0.1.0"
 

--- a/skills/constant-time-analysis/spec.yaml
+++ b/skills/constant-time-analysis/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/constant-time-analysis/skills/constant-time-analysis"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/differential-review/spec.yaml
+++ b/skills/differential-review/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/differential-review/skills/differential-review"
   version: "0.1.0"
 

--- a/skills/differential-review/spec.yaml
+++ b/skills/differential-review/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/differential-review/skills/differential-review"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/fp-check/spec.yaml
+++ b/skills/fp-check/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/fp-check/skills/fp-check"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/fp-check/spec.yaml
+++ b/skills/fp-check/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/fp-check/skills/fp-check"
   version: "0.1.0"
 

--- a/skills/insecure-defaults/spec.yaml
+++ b/skills/insecure-defaults/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/insecure-defaults/skills/insecure-defaults"
   version: "0.1.0"
 

--- a/skills/insecure-defaults/spec.yaml
+++ b/skills/insecure-defaults/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/insecure-defaults/skills/insecure-defaults"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/property-based-testing/spec.yaml
+++ b/skills/property-based-testing/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/property-based-testing/skills/property-based-testing"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/property-based-testing/spec.yaml
+++ b/skills/property-based-testing/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/property-based-testing/skills/property-based-testing"
   version: "0.1.0"
 

--- a/skills/sarif-parsing/spec.yaml
+++ b/skills/sarif-parsing/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/sarif-parsing"
   version: "0.1.0"
 

--- a/skills/sarif-parsing/spec.yaml
+++ b/skills/sarif-parsing/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/sarif-parsing"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/semgrep-rule-creator/spec.yaml
+++ b/skills/semgrep-rule-creator/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/semgrep-rule-creator/skills/semgrep-rule-creator"
   version: "0.1.0"
 

--- a/skills/semgrep-rule-creator/spec.yaml
+++ b/skills/semgrep-rule-creator/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/semgrep-rule-creator/skills/semgrep-rule-creator"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/semgrep-rule-variant-creator/spec.yaml
+++ b/skills/semgrep-rule-variant-creator/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/semgrep-rule-variant-creator/spec.yaml
+++ b/skills/semgrep-rule-variant-creator/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/semgrep-rule-variant-creator/skills/semgrep-rule-variant-creator"
   version: "0.1.0"
 

--- a/skills/semgrep/spec.yaml
+++ b/skills/semgrep/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/semgrep"
   version: "0.1.0"
 

--- a/skills/semgrep/spec.yaml
+++ b/skills/semgrep/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/static-analysis/skills/semgrep"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/sharp-edges/spec.yaml
+++ b/skills/sharp-edges/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/sharp-edges/skills/sharp-edges"
   version: "0.1.0"
 

--- a/skills/sharp-edges/spec.yaml
+++ b/skills/sharp-edges/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/sharp-edges/skills/sharp-edges"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/supply-chain-risk-auditor/spec.yaml
+++ b/skills/supply-chain-risk-auditor/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/supply-chain-risk-auditor/spec.yaml
+++ b/skills/supply-chain-risk-auditor/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/supply-chain-risk-auditor/skills/supply-chain-risk-auditor"
   version: "0.1.0"
 

--- a/skills/variant-analysis/spec.yaml
+++ b/skills/variant-analysis/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/variant-analysis/skills/variant-analysis"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/variant-analysis/spec.yaml
+++ b/skills/variant-analysis/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/variant-analysis/skills/variant-analysis"
   version: "0.1.0"
 

--- a/skills/yara-rule-authoring/spec.yaml
+++ b/skills/yara-rule-authoring/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/yara-authoring/skills/yara-rule-authoring"
   version: "0.1.0"
 

--- a/skills/yara-rule-authoring/spec.yaml
+++ b/skills/yara-rule-authoring/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/yara-authoring/skills/yara-rule-authoring"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/zeroize-audit/spec.yaml
+++ b/skills/zeroize-audit/spec.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   repository: "https://github.com/trailofbits/skills"
-  ref: "a56045e9ae00b3506cacefea0f672aab0a1a6e3c"  # main as of 2026-04-17
+  ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/zeroize-audit/skills/zeroize-audit"
   version: "0.1.0"
 

--- a/skills/zeroize-audit/spec.yaml
+++ b/skills/zeroize-audit/spec.yaml
@@ -11,7 +11,7 @@ spec:
   repository: "https://github.com/trailofbits/skills"
   ref: "cfe5d7b1619e47fb5b38b7e2561dad7e5f1e89af"  # main as of 2026-04-17
   path: "plugins/zeroize-audit/skills/zeroize-audit"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/trailofbits/skills"

--- a/skills/zeroize-audit/spec.yaml
+++ b/skills/zeroize-audit/spec.yaml
@@ -27,3 +27,10 @@ security:
       reason: "Matches the phrase 'secret argument' in tools/scripts/check_llvm_patterns.py where it labels compiler-detected patterns; the skill audits zeroization of secrets so references to the word 'secret' are expected."
     - rule_id: DATA_EXFIL_SENSITIVE_FILES
       reason: "tools/scripts/check_rust_asm.py reads a JSON config of Rust symbol names to audit; 'secrets_path' is the skill's internal config file path, not exfiltration of user secrets."
+    # FP: BEHAVIOR_EVAL_SUBPROCESS flags two list-form subprocess.run() calls,
+    # neither uses shell=True and neither takes attacker-controlled input:
+    # generate_poc.py invokes a local sibling script via sys.executable with
+    # fixed flag names; check_rust_asm.py invokes the fixed command "rustfilt"
+    # with an explicit timeout, piping asm text via stdin (not argv/shell).
+    - rule_id: BEHAVIOR_EVAL_SUBPROCESS
+      reason: "FP: matched list-form subprocess.run() calls in tools/generate_poc.py (invokes sys.executable + a local script with fixed flag names) and tools/scripts/check_rust_asm.py (invokes the fixed command 'rustfilt' with a timeout, input piped via stdin). Neither uses shell=True or attacker-controlled arguments."


### PR DESCRIPTION
## Summary
- Supersedes #699. Carries the same digest/version bump renovate proposed for all 16 trailofbits skills, plus a fix for one of six that failed `skill-security-scan`.
- `zeroize-audit`: allowlisted `BEHAVIOR_EVAL_SUBPROCESS` — verified against the actual upstream source, both flagged `subprocess.run()` calls are list-form (no `shell=True`) with fixed commands/scripts and no attacker-controlled arguments.

## Not fixed here
The other 5 skills bumped in this digest (`agentic-actions-auditor`, `codeql`, `constant-time-analysis`, `sharp-edges`, `yara-rule-authoring`) still fail `skill-security-scan`. Their logs show `Failed to parse meta-analysis response: No valid JSON found in response`, the known scanner meta-analyzer bug — dozens to hundreds of raw pattern-match findings survive as blocking when this happens, which isn't practically fixable by hand-allowlisting. This is a scanner tooling reliability issue, not a dockyard content problem.

## Test plan
- [x] Built `dockhand` locally, ran `validate-skill` against `skills/zeroize-audit/spec.yaml` — `Status: VALID`
- [ ] CI on this PR: expect `zeroize-audit` to go green, the other 5 to remain red pending the scanner bug
- [ ] Close #699 once this merges

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>