### PR TITLE
feat(skills): add 14 new mattpocock skills from upstream restructuring

### DIFF
--- a/skills/ask-matt/spec.yaml
+++ b/skills/ask-matt/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock ask-matt Skill
+# Router that recommends which skill or flow fits your situation.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/ask-matt:0.1.0
+
+metadata:
+  name: ask-matt
+  description: "Ask which skill or flow fits your situation. A router over the skills in this repo."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/ask-matt"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/codebase-design/spec.yaml
+++ b/skills/codebase-design/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock codebase-design Skill
+# Shared vocabulary for designing deep modules.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/codebase-design:0.1.0
+
+metadata:
+  name: codebase-design
+  description: "Shared vocabulary for designing deep modules. Use when the user wants to design or improve a module's interface, find deepening opportunities, decide where a seam goes, make code more testable or AI-navigable, or when another skill needs the deep-module vocabulary."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/codebase-design"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/domain-modeling/spec.yaml
+++ b/skills/domain-modeling/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock domain-modeling Skill
+# Build and sharpen a project's domain model.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/domain-modeling:0.1.0
+
+metadata:
+  name: domain-modeling
+  description: "Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/domain-modeling"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/grilling/spec.yaml
+++ b/skills/grilling/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock grilling Skill
+# Grill the user relentlessly about a plan or design.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/grilling:0.1.0
+
+metadata:
+  name: grilling
+  description: "Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/productivity/grilling"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/handoff/spec.yaml
+++ b/skills/handoff/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock handoff Skill
+# Compact the current conversation into a handoff document for another agent.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/handoff:0.1.0
+
+metadata:
+  name: handoff
+  description: "Compact the current conversation into a handoff document for another agent to pick up."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/productivity/handoff"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/implement/spec.yaml
+++ b/skills/implement/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock implement Skill
+# Implement a piece of work based on a spec or set of tickets.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/implement:0.1.0
+
+metadata:
+  name: implement
+  description: "Implement a piece of work based on a spec or set of tickets."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/implement"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/matt-pocock-code-review/spec.yaml
+++ b/skills/matt-pocock-code-review/spec.yaml
@@ -1,0 +1,25 @@
+# Matt Pocock code-review Skill
+# Two-axis review (Standards + Spec) of changes since a fixed point.
+# Source: https://github.com/mattpocock/skills
+# Vendored as matt-pocock-code-review to avoid colliding with the
+# getsentry-sourced code-review skill; upstream name is code-review.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/matt-pocock-code-review:0.1.0
+
+metadata:
+  name: matt-pocock-code-review
+  description: "Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes — Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/PRD asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to 'review since X'."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/code-review"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/prototype/spec.yaml
+++ b/skills/prototype/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock prototype Skill
+# Build a throwaway prototype to answer a design question.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/prototype:0.1.0
+
+metadata:
+  name: prototype
+  description: "Build a throwaway prototype to answer a design question. Use when the user wants to sanity-check whether a state model or logic feels right, or explore what a UI should look like."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/prototype"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/research/spec.yaml
+++ b/skills/research/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock research Skill
+# Investigate a question against high-trust primary sources and capture findings.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/research:0.1.0
+
+metadata:
+  name: research
+  description: "Investigate a question against high-trust primary sources and capture the findings as a Markdown file in the repo. Use when the user wants a topic researched, docs or API facts gathered, or reading legwork delegated to a background agent."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/research"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/resolving-merge-conflicts/spec.yaml
+++ b/skills/resolving-merge-conflicts/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock resolving-merge-conflicts Skill
+# Resolve in-progress git merge/rebase conflicts.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/resolving-merge-conflicts:0.1.0
+
+metadata:
+  name: resolving-merge-conflicts
+  description: "Use when you need to resolve an in-progress git merge/rebase conflict."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/resolving-merge-conflicts"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/teach/spec.yaml
+++ b/skills/teach/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock teach Skill
+# Teach the user a new skill or concept within this workspace.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/teach:0.1.0
+
+metadata:
+  name: teach
+  description: "Teach the user a new skill or concept, within this workspace."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/productivity/teach"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/to-spec/spec.yaml
+++ b/skills/to-spec/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock to-spec Skill
+# Turn the current conversation into a spec published to the issue tracker.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/to-spec:0.1.0
+
+metadata:
+  name: to-spec
+  description: "Turn the current conversation into a spec and publish it to the project issue tracker — no interview, just synthesis of what you've already discussed."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/to-spec"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/to-tickets/spec.yaml
+++ b/skills/to-tickets/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock to-tickets Skill
+# Break a plan or spec into tracer-bullet tickets with blocking edges.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/to-tickets:0.1.0
+
+metadata:
+  name: to-tickets
+  description: "Break a plan, spec, or the current conversation into a set of tracer-bullet tickets, each declaring its blocking edges, published to the configured tracker — edges as text in a local file, or native blocking links on a real tracker."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/to-tickets"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/wayfinder/spec.yaml
+++ b/skills/wayfinder/spec.yaml
@@ -1,0 +1,23 @@
+# Matt Pocock wayfinder Skill
+# Plan a huge chunk of work as a shared map of investigation tickets.
+# Source: https://github.com/mattpocock/skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/wayfinder:0.1.0
+
+metadata:
+  name: wayfinder
+  description: "Plan a huge chunk of work — more than one agent session can hold — as a shared map of investigation tickets on your issue tracker, and resolve them one at a time until the way to the destination is clear."
+
+spec:
+  repository: "https://github.com/mattpocock/skills"
+  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  path: "skills/engineering/wayfinder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/mattpocock/skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "mattpocock/skills is licensed MIT at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary

Stacked on #755. Onboards all new `engineering/` and `productivity/` skills from `mattpocock/skills` at `d574778` (main as of 2026-07-08), each at `version: 0.1.0`:

- **Engineering (11)**: `ask-matt`, `codebase-design`, `domain-modeling`, `implement`, `prototype`, `research`, `resolving-merge-conflicts`, `to-spec`, `to-tickets`, `wayfinder`, and upstream `code-review` — vendored as **`matt-pocock-code-review`** to avoid colliding with the existing getsentry-sourced `code-review` skill (same pattern as `entire-explain`, whose dockyard name differs from the upstream skill name).
- **Productivity (3)**: `grilling`, `handoff`, `teach`.

Upstream `in-progress/`, `personal/`, and `deprecated/` categories are intentionally skipped.

Every spec pre-allowlists `MANIFEST_MISSING_LICENSE`, matching the existing mattpocock specs: the repo is MIT-licensed at the root but doesn't embed an SPDX identifier in per-skill SKILL.md frontmatter. Any further scanner findings should be reviewed case-by-case.

Note: `ask-matt` is a router skill whose content references sibling skills by their upstream slash names (including `/code-review`); content is vendored verbatim.

## Test plan

- [ ] Skill security scan passes for all 14 new specs (or findings triaged)
- [ ] Build matrix publishes all 14 new images at 0.1.0
- [ ] Merge #755 first, then retarget/merge this PR

Made with [Cursor](https://cursor.com)