### PR TITLE
Add Nora MCP server

### DIFF
--- a/npx/nora/spec.yaml
+++ b/npx/nora/spec.yaml
@@ -1,0 +1,33 @@
+# Nora MCP Server Configuration
+# Package: https://www.npmjs.com/package/@noraai/mcp-server
+# Repository: https://github.com/solomon2773/nora
+# Will build as: ghcr.io/stacklok/dockyard/npx/nora:0.1.3
+
+metadata:
+  name: nora
+  description: "Operate self-hosted Nora agent fleets across Docker and Kubernetes"
+  protocol: npx
+
+spec:
+  package: "@noraai/mcp-server"
+  version: "0.1.3"
+
+provenance:
+  repository_uri: "https://github.com/solomon2773/nora"
+  repository_ref: "refs/heads/master"
+  attestations:
+    available: true
+    verified: true
+    publisher:
+      kind: "GitHub"
+      repository: "solomon2773/nora"
+      workflow: "release-npm.yml"
+
+security:
+  mock_env:
+    - name: NORA_API_URL
+      value: "https://mock-nora.example.com"
+      description: "Mock Nora URL for tool discovery"
+    - name: NORA_API_KEY
+      value: "nora_mock_catalog_scan_00000000"
+      description: "Mock Nora API key for tool discovery"


### PR DESCRIPTION
## Summary

- Add `@noraai/mcp-server` v0.1.3 as an npx-packaged MCP server.
- Document its GitHub Actions/npm provenance.
- Provide obvious mock Nora credentials so CI can discover and scan the default tool catalog without contacting a real Nora deployment.

Nora operates self-hosted agent fleets across Docker and Kubernetes. Its default MCP catalog exposes 15 operational and monitoring tools; destructive agent deletion is not enabled by default.

## Package links

- npm: https://www.npmjs.com/package/@noraai/mcp-server/v/0.1.3
- Source: https://github.com/solomon2773/nora
- Provenance publish run: https://github.com/solomon2773/nora/actions/runs/29171838525

## Validation

- `dockhand verify-provenance -c npx/nora/spec.yaml -v` — detected npm attestations and matched the expected repository.
- `npm audit signatures` — verified registry signatures for 94 installed packages and attestations for 8 packages.
- `dockhand build -c npx/nora/spec.yaml --check-provenance` — passed and generated the expected non-root Node container definition.
- Cisco AI Defense `mcp-scanner` 4.7.5 using the CI config-file path and both `mock_env` values — passed; 15 tools scanned, zero findings.
- Docker image build plus a second scan of the built image — passed; 15 tools scanned, zero findings.
- `go test ./...` — passed.

Note: Dockyard currently detects the npm attestation bundle but logs a multi-attestation parsing warning (`unknown field "attestations"`). The independent npm audit above cryptographically verifies the published package's registry signatures and provenance attestations.
