### PR TITLE
feat: add Okta MCP server

### DIFF
--- a/uvx/okta/spec.yaml
+++ b/uvx/okta/spec.yaml
@@ -1,0 +1,26 @@
+# Okta MCP Server Configuration
+# Official MCP server for Okta Admin Management API integration
+# Package: https://pypi.org/project/okta-mcp-server/
+# Repository: https://github.com/okta/okta-mcp-server
+# Will build as: ghcr.io/stacklok/dockyard/uvx/okta
+
+metadata:
+  name: okta
+  description: "Official Okta MCP server for managing users, groups, applications, policies, and other Okta Admin Management API resources"
+  protocol: uvx
+
+spec:
+  package: "okta-mcp-server"
+  version: "1.1.3"
+
+provenance:
+  repository_uri: "https://github.com/okta/okta-mcp-server"
+  repository_ref: "refs/tags/v1.1.3"
+
+security:
+  # Server requires a live Okta org and completes OAuth (device authorization
+  # or browserless client-credentials JWT) against it during startup before
+  # registering any tools - mock credentials fail fast via sys.exit(1) before
+  # the tool list is ever exposed, so it cannot be scanned in CI.
+  insecure_ignore: true
+  allowed_issues: []


### PR DESCRIPTION
## Summary
- Package Okta's official MCP server (`okta-mcp-server` v1.1.3), now published to PyPI, as `uvx/okta`
- Server is GA per upstream (github.com/okta/okta-mcp-server)

## Security scan
Dynamic scanning in CI is not possible: the server performs live OAuth (device authorization or browserless client-credentials JWT) against a real Okta org during startup and exits before registering any tools if that fails. Mock credentials just trigger a fast `sys.exit(1)` before a tool list is ever exposed. Marked `insecure_ignore: true`, matching the existing pattern for Sentry, PagerDuty, Neo4j, Phoenix, Browserbase, and other servers with the same constraint.

## Test plan
- [x] `task build -- uvx/okta` generates a valid Dockerfile
- [x] `docker build` succeeds
- [x] Container runs and entrypoint correctly invokes `okta-mcp-server`
- [x] Confirmed failure mode is the expected "OKTA_ORG_URL and OKTA_CLIENT_ID must be set" error, not a broken entrypoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)