### PR TITLE
ci: add concurrency groups to cancel superseded workflow runs

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -23,6 +23,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded PR runs, but let main-branch runs queue rather than
+# cancel — each push publishes/signs/attests images for that specific
+# commit, and cancelling one would silently skip its release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -27,6 +27,13 @@ on:
 
 permissions: {}
 
+# Cancel superseded PR runs, but let main-branch runs queue rather than
+# cancel — each push publishes/signs/attests artifacts for that specific
+# commit, and cancelling one would silently skip its release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:

--- a/.github/workflows/renovate-validation.yml
+++ b/.github/workflows/renovate-validation.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-config:
     name: Validate Renovate Configuration

--- a/.github/workflows/skill-version-check.yml
+++ b/.github/workflows/skill-version-check.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   skill-version-check:
     name: Check skill spec.version


### PR DESCRIPTION
## Summary
- Adds `concurrency:` groups (`${{ github.workflow }}-${{ github.ref }}`) to `ci.yml`, `renovate-validation.yml`, `skill-version-check.yml`, `build-containers.yml`, and `build-skills.yml`, so a newer push/commit cancels a stale, still-running workflow run for the same ref instead of letting both run to completion.
- `ci.yml`, `renovate-validation.yml`, `skill-version-check.yml` cancel on both `push` and `pull_request` — these are lint/validate-only with no per-commit side effects.
- `build-containers.yml` / `build-skills.yml` only cancel on `pull_request`. Their `main`-branch runs build, sign, and attest images/artifacts tied to a specific commit (via `git diff HEAD~1..HEAD`) — cancelling one would silently skip that commit's release, so those queue instead.

## Test plan
- [ ] Validate all edited workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(open(f))"` — done locally, all pass)
- [ ] Open this PR and confirm a follow-up push cancels the prior in-progress run for `ci.yml` / `renovate-validation.yml` / `skill-version-check.yml`
- [ ] Merge a small doc-only PR twice in quick succession to confirm `build-containers.yml`/`build-skills.yml` queue rather than cancel on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)