### PR TITLE
feat: support runtime env vars in spec.yaml, use for Okta keyring backend

### DIFF
--- a/.claude/skills/package-mcp-server/SKILL.md
+++ b/.claude/skills/package-mcp-server/SKILL.md
@@ -81,6 +81,8 @@ spec:
   version: "{exact-version}"
   # args:                          # Optional: CLI arguments
   #   - "start"                    # Some packages need specific commands
+  # env:                           # Optional: env vars baked into the runtime image
+  #   SOME_VAR: "some-value"       # For values the server reads at process start
 
 provenance:
   repository_uri: "{github-repo-url}"

--- a/.claude/skills/package-mcp-server/references/SPEC-YAML-REFERENCE.md
+++ b/.claude/skills/package-mcp-server/references/SPEC-YAML-REFERENCE.md
@@ -29,6 +29,8 @@ spec:
   version: string        # Required: Exact version (no ranges)
   args:                  # Optional: CLI arguments array
     - string
+  env:                   # Optional: Environment variables baked into the runtime image
+    KEY: value
 
 provenance:
   repository_uri: string    # Optional: Expected source repository URL
@@ -91,6 +93,17 @@ security:
     - "start"
     - "--port"
     - "8080"
+  ```
+
+### spec.env
+
+- **Required**: No
+- **Format**: Map of uppercase env var names to string values
+- **Purpose**: Environment variables baked into the final runtime image (not just the build stage) - for values the packaged server reads at process start, e.g. selecting a non-default backend when a dependency assumes capabilities the container doesn't have
+- **Example**:
+  ```yaml
+  env:
+    PYTHON_KEYRING_BACKEND: "keyrings.alt.file.PlaintextKeyring"
   ```
 
 ### provenance.repository_uri

--- a/.claude/skills/review-mcp-update/SKILL.md
+++ b/.claude/skills/review-mcp-update/SKILL.md
@@ -48,8 +48,14 @@ For each changed `spec.yaml`:
 3. **Check for breaking changes** that might affect:
    - Tool names or signatures
    - Required arguments (`spec.args`)
+   - Runtime environment variables (`spec.env`)
    - Authentication requirements
    - API endpoints
+
+4. **If the PR adds or changes `spec.env`**, verify:
+   - The value is non-sensitive configuration, not a secret or credential (it's committed to the repo in plaintext)
+   - The comment or PR description explains why the variable is needed at runtime (not just at build time - that's `security.mock_env`, a separate mechanism used only for scanning)
+   - It isn't being used to silently disable a security-relevant default in the packaged server
 
 ### Step 3: Verify CI Status
 
@@ -193,6 +199,8 @@ spec:
   version: "x.y.z"              # Exact version
   args:                         # Optional CLI arguments
     - "arg1"
+  env:                          # Optional env vars baked into the runtime image
+    SOME_VAR: "some-value"
 
 provenance:
   repository_uri: "https://..."

--- a/cmd/dockhand/main.go
+++ b/cmd/dockhand/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stacklok/toolhive-core/logging"
 	"github.com/stacklok/toolhive/pkg/container/images"
+	"github.com/stacklok/toolhive/pkg/container/templates"
 	"github.com/stacklok/toolhive/pkg/runner"
 	"gopkg.in/yaml.v3"
 
@@ -41,9 +42,10 @@ type MCPServerMetadata struct {
 
 // MCPServerPackageSpec defines the package to be containerized
 type MCPServerPackageSpec struct {
-	Package string   `yaml:"package"`           // e.g., "@upstash/context7-mcp"
-	Version string   `yaml:"version,omitempty"` // e.g., "1.0.14"
-	Args    []string `yaml:"args,omitempty"`    // Additional arguments for the package
+	Package string            `yaml:"package"`           // e.g., "@upstash/context7-mcp"
+	Version string            `yaml:"version,omitempty"` // e.g., "1.0.14"
+	Args    []string          `yaml:"args,omitempty"`    // Additional arguments for the package
+	Env     map[string]string `yaml:"env,omitempty"`     // Environment variables baked into the runtime image
 }
 
 // MCPServerProvenance contains supply chain provenance information
@@ -368,6 +370,12 @@ func generateDockerfile(ctx context.Context, spec *MCPServerSpec, customTag stri
 	// Create image manager
 	imageManager := images.NewImageManager(ctx)
 
+	// Pass runtime env vars through as a RuntimeConfig override, if declared
+	var runtimeOverride *templates.RuntimeConfig
+	if len(spec.Spec.Env) > 0 {
+		runtimeOverride = &templates.RuntimeConfig{RuntimeEnv: spec.Spec.Env}
+	}
+
 	// Generate Dockerfile using toolhive's BuildFromProtocolSchemeWithName function with dryRun=true
 	dockerfile, err := runner.BuildFromProtocolSchemeWithName(
 		ctx,
@@ -376,8 +384,8 @@ func generateDockerfile(ctx context.Context, spec *MCPServerSpec, customTag stri
 		"", // caCertPath - empty for now
 		imageTag,
 		spec.Spec.Args, // Pass args from spec if present
-		nil,            // runtimeOverride - use defaults
-		true,           // always dryRun to generate Dockerfile
+		runtimeOverride,
+		true, // always dryRun to generate Dockerfile
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate Dockerfile for protocol scheme %s: %w", protocolScheme, err)

--- a/docs/adding-servers.md
+++ b/docs/adding-servers.md
@@ -40,6 +40,8 @@ spec:
   args:                            # Optional: CLI arguments for the package
     - "arg1"                       # Passed to the entrypoint command
     - "arg2"
+  env:                             # Optional: env vars baked into the runtime image
+    SOME_VAR: "some-value"         # Present in the running container, not just at build time
 
 provenance:                        # Optional but recommended
   repository_uri: "https://github.com/user/repo"
@@ -228,7 +230,7 @@ security:
       reason: "Destructive flow mitigated by container sandboxing"
 ```
 
-### Servers Requiring Environment Variables
+### Servers Requiring Environment Variables During Scanning
 
 Some MCP servers require environment variables to start (e.g., API URLs, tokens). Since the security scanner needs to start the server to discover its tools, you can provide mock values that allow the server to start without functional credentials:
 
@@ -247,9 +249,26 @@ security:
 - Mock values are **not secrets** - they are committed to the repository
 - Values should be obviously fake (use `mock-`, placeholder UUIDs, example.com domains)
 - Purpose is to allow server startup for scanning, not functional operation
+- Only consumed by the scan tooling (`scripts/mcp-scan/`) - it is **not** wired into the built container
 - Servers still need to pass security scans or allowlist known issues
 
 See [Security Overview](security.md) for more details on what we scan for.
+
+### Servers Requiring Environment Variables at Runtime
+
+`security.mock_env` above only affects scanning. If your server actually needs an environment variable set in the **shipped, running container** - for example, to select a non-default backend when a dependency assumes capabilities the container doesn't have - use `spec.env` instead:
+
+```yaml
+spec:
+  package: "your-package-name"
+  version: "1.0.0"
+  env:
+    PYTHON_KEYRING_BACKEND: "keyrings.alt.file.PlaintextKeyring"
+```
+
+This is baked into the final stage of the generated Dockerfile as an `ENV` instruction, so it's present in the process environment every time the container runs - not just during the build. `uvx/okta/spec.yaml` uses this for exactly this reason: `okta-mcp-server` caches OAuth tokens via Python's `keyring` library, which otherwise tries to reach an OS secret-service/D-Bus backend that doesn't exist in the container.
+
+Don't use `spec.env` to embed secrets or credentials - it's committed to the repository just like the rest of `spec.yaml`. It's for non-sensitive configuration values only.
 
 ### After Merge
 

--- a/uvx/okta/spec.yaml
+++ b/uvx/okta/spec.yaml
@@ -12,6 +12,11 @@ metadata:
 spec:
   package: "okta-mcp-server"
   version: "1.1.3"
+  env:
+    # okta-mcp-server caches OAuth tokens via the `keyring` library, which
+    # otherwise tries to reach an OS secret-service/D-Bus backend that
+    # doesn't exist in this minimal container.
+    PYTHON_KEYRING_BACKEND: "keyrings.alt.file.PlaintextKeyring"
 
 provenance:
   repository_uri: "https://github.com/okta/okta-mcp-server"


### PR DESCRIPTION
## Summary
- toolhive v0.38.0 added `RuntimeConfig.RuntimeEnv`, which bakes environment variables into the final runtime stage of generated Dockerfiles (as opposed to `BuildEnv`, which only affects the builder stage). Wire this through dockhand as a new `spec.env` field in spec.yaml.
- Use it for `uvx/okta`: `okta-mcp-server` caches OAuth tokens via Python's `keyring` library, which otherwise tries to reach an OS secret-service/D-Bus backend that doesn't exist in the container. Setting `PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring` (the backend upstream recommends for headless/containerized use, and already a declared dependency of the package) fixes token caching at runtime.
- Updated the packaging skill docs (`SPEC-YAML-REFERENCE.md`, `package-mcp-server/SKILL.md`, `docs/adding-servers.md`, `review-mcp-update/SKILL.md`) so the new field is documented for future contributors and reviewers, and clearly distinguished from `security.mock_env` (which only affects scanning, not the shipped image).

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] `dockhand build -c uvx/okta/spec.yaml` generates the expected `ENV PYTHON_KEYRING_BACKEND="keyrings.alt.file.PlaintextKeyring"` line in the final Dockerfile stage
- [x] `docker build` succeeds
- [x] Confirmed via the installed venv's Python that `keyring.get_keyring()` resolves to `keyrings.alt.file.PlaintextKeyring` and a token round-trips through `set_password`/`get_password` without needing an OS secret-service backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)