### PR TITLE
chore(renovate): split CI runtime versions out of the actions group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,12 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
       "groupName": "github-actions"
+    },
+    {
+      "description": "Keep runtime toolchain versions (the github-actions manager extracts these from setup-* `with:` inputs, e.g. actions/setup-python's python-version) out of the github-actions digest group. These are feature-release decisions - for CPython, 3.13 to 3.14 is not a true semver-minor - so they warrant their own reviewable PR rather than riding along with action digest bumps. Ordered after the group rule so it wins.",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["uses-with"],
+      "groupName": "CI runtime versions"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Follow-up to the Renovate grouping in #780. The `github-actions` manager doesn't only track action digests, it also extracts runtime versions from `setup-*` `with:` inputs (like `actions/setup-python`'s `python-version`) as dependencies with `depType: uses-with`. Those were falling into the `github-actions` group, so in #787 a `python-version` `3.13 → 3.14` bump rode along with an unrelated `setup-uv` patch in a single PR.

For CPython, a minor bump is a feature release, not a true semver-minor, so it deserves deliberate review rather than getting entangled with routine digest bumps. This adds a rule (ordered after the actions group so it wins) that gives `uses-with` deps their own **CI runtime versions** group.

Result:
- Action digest bumps stay grouped as `github-actions`.
- `python-version` comes as its own reviewable PR you can merge or close on its own.
- Since both build workflows pin the same `python-version`, they move together in that one PR.

Right now `uses-with` matches only `python-version` (the `node-version: '24'` pin is major-only and already excluded from the group; `go-version` uses `go-version-file`, not a literal). The rule is written generically so any future runtime pin is handled the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)