### PR TITLE
ci: smoke-test scan legs on workflow/scan-script changes

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -404,10 +404,13 @@ jobs:
     # gate` step below, which reads scan-summary.json from the artifact
     # produced by mcp-security-scan. verify-provenance is informational.
     #
-    # Skipped entirely on smoke runs (workflow/scan-script-only changes): those
-    # exercise verify-provenance and mcp-security-scan on a representative
-    # sample but must not build or publish any image.
-    if: ${{ !cancelled() && needs.discover-configs.outputs.changed-configs != '[]' && needs.verify-provenance.result == 'success' && needs.discover-configs.outputs.smoke != 'true' }}
+    # On smoke runs (workflow/scan-script-only changes) this builds the
+    # representative sample on PRs to exercise the build path (Dockerfile
+    # generation, buildx, Grype) but never pushes — the push/sign/attest
+    # steps are already gated on `github.event_name != 'pull_request'`. On
+    # pushes to main, smoke skips the build entirely so a workflow edit does
+    # not publish, sign, or attest a sample image.
+    if: ${{ !cancelled() && needs.discover-configs.outputs.changed-configs != '[]' && needs.verify-provenance.result == 'success' && (needs.discover-configs.outputs.smoke != 'true' || github.event_name == 'pull_request') }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-configs.outputs.changed-configs) }}

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -8,6 +8,9 @@ on:
       - 'uvx/**/*.yaml'
       - 'go/**/*.yaml'
       - 'cmd/dockhand/**'
+      - 'scripts/mcp-scan/**'
+      - '.github/workflows/build-containers.yml'
+      - '.github/workflows/mcp-scan-report.yml'
       - 'go.mod'
       - 'go.sum'
   pull_request:
@@ -17,6 +20,9 @@ on:
       - 'uvx/**/*.yaml'
       - 'go/**/*.yaml'
       - 'cmd/dockhand/**'
+      - 'scripts/mcp-scan/**'
+      - '.github/workflows/build-containers.yml'
+      - '.github/workflows/mcp-scan-report.yml'
       - 'go.mod'
       - 'go.sum'
   workflow_dispatch:
@@ -48,6 +54,7 @@ jobs:
       configs: ${{ steps.find-configs.outputs.configs }}
       changed-configs: ${{ steps.find-configs.outputs.changed-configs }}
       scan-configs: ${{ steps.find-configs.outputs.scan-configs }}
+      smoke: ${{ steps.find-configs.outputs.smoke }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -82,6 +89,10 @@ jobs:
             fi
             return 1
           }
+
+          # Smoke mode: set when the only relevant change is to this workflow
+          # or the scan scripts. See the block after the event dispatch below.
+          smoke=false
 
           if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             # For manual triggers, build all configs
@@ -134,6 +145,29 @@ jobs:
             fi
           fi
 
+          # If the only relevant change was to this workflow or the scan
+          # scripts (no spec changed, no full rebuild triggered), run a small
+          # representative sample — one config per protocol — through the
+          # verify-provenance and mcp-security-scan legs. This exercises the
+          # scan/verify toolchain (e.g. a Python or scanner bump) without
+          # building or pushing every image. build-containers is skipped for
+          # smoke runs via the `smoke` output.
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] \
+             && [ -z "$configs_to_build" ] \
+             && echo "$changed_files" | grep -qE "(^\.github/workflows/build-containers\.yml$|^\.github/workflows/mcp-scan-report\.yml$|^scripts/mcp-scan/)"; then
+            echo "Only workflow/scan-script changed - smoke testing a representative sample (no build/push)"
+            sample=""
+            for proto in npx uvx go; do
+              first=$(find "$proto" -name "spec.yaml" -type f 2>/dev/null | sort | head -1)
+              if [ -n "$first" ]; then
+                sample="$sample$first"$'\n'
+              fi
+            done
+            configs_to_build="$sample"
+            configs_to_scan="$sample"
+            smoke=true
+          fi
+
           # Convert to JSON array, filtering out empty lines
           configs_json=$(echo "$configs_to_build" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
           scan_configs_json=$(echo "$configs_to_scan" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
@@ -142,6 +176,7 @@ jobs:
           echo "configs=$all_configs_json" >> $GITHUB_OUTPUT
           echo "changed-configs=$configs_json" >> $GITHUB_OUTPUT
           echo "scan-configs=$scan_configs_json" >> $GITHUB_OUTPUT
+          echo "smoke=$smoke" >> $GITHUB_OUTPUT
 
           echo "All configurations: $all_configs_json"
           echo "Configurations to build: $configs_json"
@@ -368,7 +403,11 @@ jobs:
     # build. The security gate is preserved per-cell by the `Pre-flight scan
     # gate` step below, which reads scan-summary.json from the artifact
     # produced by mcp-security-scan. verify-provenance is informational.
-    if: ${{ !cancelled() && needs.discover-configs.outputs.changed-configs != '[]' && needs.verify-provenance.result == 'success' }}
+    #
+    # Skipped entirely on smoke runs (workflow/scan-script-only changes): those
+    # exercise verify-provenance and mcp-security-scan on a representative
+    # sample but must not build or publish any image.
+    if: ${{ !cancelled() && needs.discover-configs.outputs.changed-configs != '[]' && needs.verify-provenance.result == 'success' && needs.discover-configs.outputs.smoke != 'true' }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-configs.outputs.changed-configs) }}

--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -340,10 +340,13 @@ jobs:
     # individual skill level by reading scan-summary.json from the artifact
     # produced by skill-security-scan (uploaded with `if: always()`).
     #
-    # Skipped entirely on smoke runs (workflow/scan-script-only changes): those
-    # exercise validate-skills and skill-security-scan on a representative
-    # skill but must not build or republish any artifact.
-    if: ${{ !cancelled() && needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' && needs.discover-skill-configs.outputs.smoke != 'true' }}
+    # On smoke runs (workflow/scan-script-only changes) this builds the
+    # representative skill on PRs to exercise the build path (dockhand
+    # build-skill) but never pushes — the push/sign/SBOM/attest steps are
+    # already gated on `github.event_name != 'pull_request'`. On pushes to
+    # main, smoke skips the build entirely so a workflow edit does not
+    # republish, sign, or attest a sample artifact.
+    if: ${{ !cancelled() && needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' && (needs.discover-skill-configs.outputs.smoke != 'true' || github.event_name == 'pull_request') }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-skill-configs.outputs.changed-configs) }}

--- a/.github/workflows/build-skills.yml
+++ b/.github/workflows/build-skills.yml
@@ -50,6 +50,7 @@ jobs:
     outputs:
       changed-configs: ${{ steps.find-configs.outputs.changed-configs }}
       scan-configs: ${{ steps.find-configs.outputs.scan-configs }}
+      smoke: ${{ steps.find-configs.outputs.smoke }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -73,16 +74,18 @@ jobs:
           fi
 
           # Decide whether a change to core build inputs warrants rebuilding
-          # every skill. dockhand source, the skills packaging library, the
-          # scan scripts, and this workflow always trigger a full rebuild.
-          # go.mod/go.sum only count when the toolhive modules changed — they
-          # drive the OCI packaging (internal/skills, cmd/dockhand), so a bump
-          # there can alter every artifact. Unrelated dependency bumps must not
-          # rebuild all ~160 skills (it floods GHCR and hits its rate limit).
+          # every skill. Only inputs that alter the built artifact do: dockhand
+          # source and the skills packaging library. go.mod/go.sum count only
+          # when the toolhive modules changed — they drive the OCI packaging
+          # (internal/skills, cmd/dockhand), so a bump there can alter every
+          # artifact. Unrelated dependency bumps must not rebuild all ~160
+          # skills (it floods GHCR and hits its rate limit). Changes to the
+          # scan scripts or this workflow do not alter artifacts, so they are
+          # handled as a smoke test below rather than a full rebuild.
           # Args: $1 = git diff range, $2 = newline-separated changed files.
           core_rebuild_needed() {
             local range="$1" changed="$2"
-            if echo "$changed" | grep -qE "(cmd/dockhand/|internal/skills/|scripts/skill-scan/|\.github/workflows/build-skills\.yml)"; then
+            if echo "$changed" | grep -qE "(cmd/dockhand/|internal/skills/)"; then
               return 0
             fi
             if echo "$changed" | grep -qE "^go\.(mod|sum)$"; then
@@ -92,6 +95,10 @@ jobs:
             fi
             return 1
           }
+
+          # Smoke mode: set when the only relevant change is to this workflow
+          # or the scan scripts. See the block after the event dispatch below.
+          smoke=false
 
           if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             configs_to_build="$all_configs"
@@ -137,10 +144,28 @@ jobs:
             fi
           fi
 
+          # If the only relevant change was to this workflow or the scan
+          # scripts (no spec changed, no full rebuild triggered), run a single
+          # representative skill through the validate-skills and
+          # skill-security-scan legs. This exercises the scan/validate
+          # toolchain (e.g. a Python or scanner bump) without rebuilding or
+          # republishing every skill. build-skill-artifacts is skipped for
+          # smoke runs via the `smoke` output.
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] \
+             && [ -z "$configs_to_build" ] \
+             && echo "$changed_files" | grep -qE "(^\.github/workflows/build-skills\.yml$|^\.github/workflows/skill-scan-report\.yml$|^scripts/skill-scan/)"; then
+            echo "Only workflow/scan-script changed - smoke testing a representative skill (no build/push)"
+            sample=$(find skills -name "spec.yaml" -type f 2>/dev/null | sort | head -1)
+            configs_to_build="$sample"
+            configs_to_scan="$sample"
+            smoke=true
+          fi
+
           configs_json=$(echo "$configs_to_build" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
           scan_configs_json=$(echo "$configs_to_scan" | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
           echo "changed-configs=$configs_json" >> $GITHUB_OUTPUT
           echo "scan-configs=$scan_configs_json" >> $GITHUB_OUTPUT
+          echo "smoke=$smoke" >> $GITHUB_OUTPUT
           echo "Skill configurations to build: $configs_json"
           echo "Skill configurations to scan: $scan_configs_json"
 
@@ -314,7 +339,11 @@ jobs:
     # `Pre-flight scan gate` step below preserves the security gate at the
     # individual skill level by reading scan-summary.json from the artifact
     # produced by skill-security-scan (uploaded with `if: always()`).
-    if: ${{ !cancelled() && needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' }}
+    #
+    # Skipped entirely on smoke runs (workflow/scan-script-only changes): those
+    # exercise validate-skills and skill-security-scan on a representative
+    # skill but must not build or republish any artifact.
+    if: ${{ !cancelled() && needs.discover-skill-configs.outputs.changed-configs != '[]' && needs.validate-skills.result == 'success' && needs.discover-skill-configs.outputs.smoke != 'true' }}
     strategy:
       matrix:
         config: ${{ fromJson(needs.discover-skill-configs.outputs.changed-configs) }}


### PR DESCRIPTION
Fixes an asymmetry between the two build pipelines that let a scan-toolchain regression merge with green CI.

### The problem
`build-containers.yml` didn't list its own workflow file or `scripts/mcp-scan/**` in its trigger paths, so edits there ran **nothing**. That's how #787 (a `python-version` 3.13 → 3.14 bump in the scan job) showed all-green: the container pipeline never ran, and only the skills side exercised 3.14.

`build-skills.yml` had the opposite problem: a workflow edit tripped `core_rebuild_needed` and **rebuilt and republished all ~160 skills**, even though a workflow or scan-script change doesn't alter the built artifact.

### The change
Both workflows now trigger on their own workflow file and their scan scripts, and when that's the *only* change they run a **smoke test**: a small representative sample (one config per protocol for containers, one skill for skills) through the verify/validate and security-scan legs. On PRs the sample is also **built (without pushing)** to exercise the build path; on pushes to main the build is skipped so a workflow edit never publishes a sample image. A new `smoke` job output controls this.

- Container smoke sample: first `npx` + first `uvx` spec (and `go` when present).
- Skill smoke sample: first skill spec.
- `build-skills` no longer full-rebuilds on scan-script/workflow edits; those are artifact-neutral and now smoke-tested instead.

Normal spec changes and core-input changes (dockhand, `internal/skills`, toolhive `go.mod`) behave exactly as before.

This PR edits both workflow files, so it exercises the new smoke path on itself: `build-containers` and `build-skills` should run their verify/validate + scan legs on a small sample and build it without pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)