### PR TITLE
fix(skills): sync mattpocock/skills to a621cc4, add graduates

### DIFF
--- a/skills/ask-matt/spec.yaml
+++ b/skills/ask-matt/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/ask-matt"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/codebase-design/spec.yaml
+++ b/skills/codebase-design/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/codebase-design"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/diagnosing-bugs/spec.yaml
+++ b/skills/diagnosing-bugs/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/diagnosing-bugs"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/domain-modeling/spec.yaml
+++ b/skills/domain-modeling/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/domain-modeling"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/git-guardrails-claude-code/spec.yaml
+++ b/skills/git-guardrails-claude-code/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/misc/git-guardrails-claude-code"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/grill-me/spec.yaml
+++ b/skills/grill-me/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/productivity/grill-me"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/grilling/spec.yaml
+++ b/skills/grilling/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "ed37663cc5fbef691ddfecd080dff42f7e7e350d"
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/productivity/grilling"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/handoff/spec.yaml
+++ b/skills/handoff/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/productivity/handoff"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/implement/spec.yaml
+++ b/skills/implement/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/implement"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/improve-codebase-architecture/spec.yaml
+++ b/skills/improve-codebase-architecture/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/improve-codebase-architecture"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/matt-pocock-code-review/spec.yaml
+++ b/skills/matt-pocock-code-review/spec.yaml
@@ -11,9 +11,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/code-review"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/migrate-to-shoehorn/spec.yaml
+++ b/skills/migrate-to-shoehorn/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/misc/migrate-to-shoehorn"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/prototype/spec.yaml
+++ b/skills/prototype/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/prototype"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/research/spec.yaml
+++ b/skills/research/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/research"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/resolving-merge-conflicts/spec.yaml
+++ b/skills/resolving-merge-conflicts/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/resolving-merge-conflicts"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/scaffold-exercises/spec.yaml
+++ b/skills/scaffold-exercises/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/misc/scaffold-exercises"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/setup-matt-pocock-skills/spec.yaml
+++ b/skills/setup-matt-pocock-skills/spec.yaml
@@ -10,9 +10,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/setup-matt-pocock-skills"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/setup-pre-commit/spec.yaml
+++ b/skills/setup-pre-commit/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/misc/setup-pre-commit"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/tdd/spec.yaml
+++ b/skills/tdd/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/tdd"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/teach/spec.yaml
+++ b/skills/teach/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/productivity/teach"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/to-questionnaire/spec.yaml
+++ b/skills/to-questionnaire/spec.yaml
@@ -1,16 +1,16 @@
-# Matt Pocock writing-great-skills Skill
-# Reference for writing and editing skills well.
+# Matt Pocock to-questionnaire Skill
+# Turn a decision you can't fully answer into a questionnaire for someone else.
 # Source: https://github.com/mattpocock/skills
-# Will publish as: ghcr.io/stacklok/dockyard/skills/writing-great-skills:0.1.0
+# Will publish as: ghcr.io/stacklok/dockyard/skills/to-questionnaire:0.1.0
 
 metadata:
-  name: writing-great-skills
-  description: "Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable."
+  name: to-questionnaire
+  description: "Turn a decision you can't fully answer into a questionnaire for someone else to fill in."
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
-  path: "skills/productivity/writing-great-skills"
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  path: "skills/productivity/to-questionnaire"
   version: "0.1.0"
 
 provenance:

--- a/skills/to-spec/spec.yaml
+++ b/skills/to-spec/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/to-spec"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/to-tickets/spec.yaml
+++ b/skills/to-tickets/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/to-tickets"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/triage/spec.yaml
+++ b/skills/triage/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/triage"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/wayfinder/spec.yaml
+++ b/skills/wayfinder/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "d574778f94cf620fcc8ce741584093bc650a61d3"  # main as of 2026-07-08
+  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
   path: "skills/engineering/wayfinder"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/wizard/spec.yaml
+++ b/skills/wizard/spec.yaml
@@ -1,17 +1,17 @@
-# Matt Pocock grill-with-docs Skill
-# Grilling session that challenges your plan against the existing domain model.
+# Matt Pocock wizard Skill
+# Generate an interactive bash wizard for manual procedures.
 # Source: https://github.com/mattpocock/skills
-# Will publish as: ghcr.io/stacklok/dockyard/skills/grill-with-docs:0.1.0
+# Will publish as: ghcr.io/stacklok/dockyard/skills/wizard:0.1.0
 
 metadata:
-  name: grill-with-docs
-  description: "A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go."
+  name: wizard
+  description: "Generate an interactive bash wizard that walks a human through a manual procedure — third-party setup, a one-off migration, an A→B state transition — opening URLs, capturing values, confirming each step, and writing .env files and GitHub Actions secrets."
 
 spec:
   repository: "https://github.com/mattpocock/skills"
   ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
-  path: "skills/engineering/grill-with-docs"
-  version: "0.3.0"
+  path: "skills/engineering/wizard"
+  version: "0.1.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/writing-for-agents/spec.yaml
+++ b/skills/writing-for-agents/spec.yaml
@@ -1,17 +1,17 @@
-# Matt Pocock grill-with-docs Skill
-# Grilling session that challenges your plan against the existing domain model.
+# Matt Pocock writing-for-agents Skill
+# Reference for writing documents agents consume — skills, AGENTS.md, CLAUDE.md.
 # Source: https://github.com/mattpocock/skills
-# Will publish as: ghcr.io/stacklok/dockyard/skills/grill-with-docs:0.1.0
+# Will publish as: ghcr.io/stacklok/dockyard/skills/writing-for-agents:0.1.0
 
 metadata:
-  name: grill-with-docs
-  description: "A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go."
+  name: writing-for-agents
+  description: "Writing documents for agents. Use when creating or editing skills, or modifying AGENTS.md or CLAUDE.md."
 
 spec:
   repository: "https://github.com/mattpocock/skills"
   ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
-  path: "skills/engineering/grill-with-docs"
-  version: "0.3.0"
+  path: "skills/productivity/writing-for-agents"
+  version: "0.1.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"


### PR DESCRIPTION
## Summary

Syncs all vendored [mattpocock/skills](https://github.com/mattpocock/skills) packages from `d574778` (main as of 2026-07-08) to `a621cc4` (main as of 2026-08-05):

- **Ref bump + version bump** for 25 existing mattpocock skills (minor bumps via `skillversionbump`)
- **Removed/Renamed:** `writing-great-skills` → `writing-for-agents` (upstream path `skills/productivity/writing-for-agents`)
- **Added:** `wizard` (`skills/engineering/wizard`), `to-questionnaire` (`skills/productivity/to-questionnaire`) — both at `0.1.0`

Supersedes Renovate #691 (which targeted older digest `2ab9580`).

## Test plan

- [ ] `skill-version-check` CI passes
- [ ] `build-skills` CI builds and scans all touched mattpocock packages
- [ ] Confirm `writing-great-skills` OCI image is no longer published; consumers should use `writing-for-agents`