### PR TITLE
fix: clear the Grype vulnerability backlog via spec overrides

### DIFF
--- a/npx/astra-db-mcp/spec.yaml
+++ b/npx/astra-db-mcp/spec.yaml
@@ -12,6 +12,20 @@ metadata:
 spec:
   package: "@datastax/astra-db-mcp"
   version: "1.2.2"
+  overrides:
+    - package: "undici"
+      version: "6.28.0"
+      reason: |
+        undici 5.29.0 arrives via astra-db-mcp -> mcp-evals -> @actions/core ->
+        @actions/http-client, which caps it at ^5.25.4. The 5.x line is end of
+        life, so the fixes for GHSA-vrm6-8vpv-qv8q and GHSA-v9p9-hfj2-hcw8
+        (both 6.24.0) and GHSA-vxpw-j846-p89q (6.27.0) only exist in 6.x.
+        6.28.0 is the last 6.x release and no high advisory affects >=6.27.0
+        on that line, so it clears all three without stepping into the 7.x
+        advisories (GHSA-hm92-r4w5-c3mj, GHSA-vmh5-mc38-953g, GHSA-4cwx-7wf7-3272).
+        Cross-major force, but @actions/http-client 4.0.1 upstream has itself
+        moved to undici ^6.23.0, so 6.x is a supported target for this consumer,
+        and the tool list still enumerates.
 
 provenance:
   repository_uri: "https://github.com/datastax/astra-db-mcp"

--- a/npx/brightdata-mcp/spec.yaml
+++ b/npx/brightdata-mcp/spec.yaml
@@ -12,6 +12,16 @@ metadata:
 spec:
   package: "@brightdata/mcp"
   version: "2.9.0"
+  overrides:
+    - package: "@modelcontextprotocol/sdk"
+      version: "1.26.0"
+      reason: |
+        @brightdata/mcp exact-pins @modelcontextprotocol/sdk 1.21.2, which carries
+        GHSA-w48q-cv73-mx4w (DNS rebinding, fixed 1.24.0), GHSA-8r9q-7v3j-jr4g
+        (ReDoS, fixed 1.25.2) and GHSA-345p-7cg4-v4c7 (affects >=1.10.0,<=1.25.3,
+        fixed 1.26.0). 1.26.0 is the lowest version that clears all three: 1.25.2
+        would still be inside the GHSA-345p range. Same-major, and the server's
+        tools still enumerate correctly.
 
 provenance:
   repository_uri: "https://github.com/brightdata/brightdata-mcp"

--- a/npx/browserbase-mcp-server/spec.yaml
+++ b/npx/browserbase-mcp-server/spec.yaml
@@ -12,6 +12,29 @@ metadata:
 spec:
   package: "@browserbasehq/mcp-server-browserbase"
   version: "2.4.3"
+  overrides:
+    - package: "sharp"
+      version: "0.35.3"
+      reason: |
+        @browserbasehq/mcp-server-browserbase caps sharp at ^0.33.0, resolving
+        0.33.5. GHSA-f88m-g3jw-g9cj (inherited libvips CVE-2026-33327,
+        CVE-2026-33328, CVE-2026-35590, CVE-2026-35591) affects all sharp <0.35.0,
+        so no 0.33.x or 0.34.x release can fix it. 0.35.3 is the newest 0.35.x
+        and is the only sharp advisory in play. sharp 0.x minors are breaking by
+        convention, so this is effectively a cross-major force; verified in the
+        container that sharp loads and round-trips a resize on the pinned version.
+    - package: "undici"
+      version: "6.28.0"
+      reason: |
+        undici 5.29.0 arrives via @browserbasehq/stagehand ->
+        @ai-sdk/amazon-bedrock -> @ai-sdk/provider-utils, which caps it at
+        ^5.29.0. The 5.x line is end of life, so the fixes for
+        GHSA-vrm6-8vpv-qv8q and GHSA-v9p9-hfj2-hcw8 (both 6.24.0) and
+        GHSA-vxpw-j846-p89q (6.27.0) only exist in 6.x. 6.28.0 is the last 6.x
+        release and no high advisory affects >=6.27.0 on that line, so it clears
+        all three without stepping into the 7.x advisories. Cross-major force,
+        but @ai-sdk/provider-utils 5.x upstream has itself moved to undici
+        ^7.28.0, so this consumer tracks well past 6.x.
 
 provenance:
   repository_uri: "https://github.com/browserbase/mcp-server-browserbase"

--- a/npx/mcp-jetbrains/spec.yaml
+++ b/npx/mcp-jetbrains/spec.yaml
@@ -12,6 +12,16 @@ metadata:
 spec:
   package: "@jetbrains/mcp-proxy"
   version: "1.8.0"
+  overrides:
+    - package: "@modelcontextprotocol/sdk"
+      version: "1.26.0"
+      reason: |
+        @jetbrains/mcp-proxy exact-pins @modelcontextprotocol/sdk 1.7.0, which
+        carries GHSA-w48q-cv73-mx4w (DNS rebinding, fixed 1.24.0) and
+        GHSA-8r9q-7v3j-jr4g (ReDoS, fixed 1.25.2). 1.26.0 rather than 1.25.2
+        because GHSA-345p-7cg4-v4c7 affects >=1.10.0,<=1.25.3, which the pinned
+        1.7.0 predates, so a smaller bump would trade two advisories for a third.
+        Same-major, and the proxy still starts and serves its tool list.
 
 provenance:
   repository_uri: "https://github.com/JetBrains/mcp-jetbrains"

--- a/uvx/adb-mysql-mcp-server/spec.yaml
+++ b/uvx/adb-mysql-mcp-server/spec.yaml
@@ -19,6 +19,13 @@ spec:
         mcp 2.0.0 removed the mcp.server.fastmcp module the server imports at
         startup, so the container fails immediately with ModuleNotFoundError.
         Cap it below 2 until upstream pins the dependency themselves.
+    - spec: "cryptography>=50.0.0"
+      reason: |
+        alibabacloud-tea-openapi caps cryptography <49.0.0 for python>=3.9, but
+        the fix for GHSA-g6cj-pr64-35w5 (High, Bleichenbacher oracle in PKCS#7
+        EnvelopedData decryption) is cryptography 50.0.0. Verified that the
+        server's imports and the RSA signing primitive the SDK uses still work
+        with 50.0.0.
 
 provenance:
   repository_uri: "https://github.com/aliyun/alibabacloud-adb-mysql-mcp-server"

--- a/uvx/chroma-mcp/spec.yaml
+++ b/uvx/chroma-mcp/spec.yaml
@@ -12,6 +12,18 @@ metadata:
 spec:
   package: "chroma-mcp"
   version: "0.2.6"
+  constraints:
+    - spec: "mcp[cli]>=1.28.1,<2"
+      reason: |
+        chroma-mcp 0.2.6 exact-pins mcp[cli]==1.6.0, which excludes every fix
+        for its 5 HIGH findings: GHSA-3qhf-m339-9g5v (1.9.4),
+        GHSA-j975-95f5-7wqh (1.10.0), GHSA-9h52-p55h-vw2f (1.23.0),
+        GHSA-jpw9-pfvf-9f58 (1.27.2) and GHSA-vj7q-gjh5-988w (1.28.1).
+        1.28.1 is the lowest version clearing all five: a smaller bump to
+        1.23.0 would newly expose GHSA-hvrp-rf83-w775 (HIGH,
+        >=1.23.0,<=1.27.1), which 1.6.0 predates. Capped <2 so uv cannot
+        resolve the mcp 2.x major. chroma-mcp only imports
+        mcp.server.fastmcp.FastMCP, which is stable across the 1.x line.
 
 provenance:
   repository_uri: "https://github.com/chroma-core/chroma-mcp"


### PR DESCRIPTION
Uses the override mechanism from #669 / #831 to clear 6 of the 10 servers failing the `build-containers` Grype gate. The other 4 turned out not to be override-shaped; details below.

Closes #828
Closes #830

## Fixed

| Server | Override | Findings cleared |
|---|---|---|
| `uvx/adb-mysql-mcp-server` | `cryptography>=50.0.0` | 1 high |
| `uvx/chroma-mcp` | `mcp[cli]>=1.28.1,<2` | 5 high |
| `npx/brightdata-mcp` | SDK 1.26.0 | 3 high |
| `npx/mcp-jetbrains` | SDK 1.26.0 | 2 high |
| `npx/astra-db-mcp` | `undici` 6.28.0 | 3 high |
| `npx/browserbase-mcp-server` | `sharp` 0.35.3, `undici` 6.28.0 | 4 high |

Every one is an upstream pin or cap that excludes the available fix, which is exactly the case #668 described. Each `reason` field records the pin, the advisories, and why that specific target version.

## Version selection

Picking the minimum fixed version is wrong more often than not, because a small bump can step into an advisory the pinned version predated. Concrete cases here:

- `brightdata` and `jetbrains`: the two highs are fixed at 1.24.0 and 1.25.2, but GHSA-345p-7cg4-v4c7 affects `>=1.10.0,<=1.25.3`, which the pinned 1.21.2 / 1.7.0 escape. 1.25.2 would trade two advisories for a third, so 1.26.0.
- `chroma-mcp`: five advisories are cleared by 1.28.1, but a smaller bump to 1.23.0 would newly expose GHSA-hvrp-rf83-w775 (`>=1.23.0,<=1.27.1`).
- `astra-db` and `browserbase`: `undici` 5.x is EOL so the fixes only exist in 6.x. Pinned to 6.28.0, the last 6.x, deliberately stopping short of 7.x-only advisories.
- `chroma-mcp` is capped `<2` because `mcp` 2.0.0 removed the module the server imports, which is the failure that started all of this.

Three are cross-major forces (`undici` 5 to 6 twice, `sharp` 0.33 to 0.35) and are flagged as such in their reasons.

## Verification

Per server: `dockhand build` then `docker build` then `grype --fail-on high --only-fixed` from the repo root so `.grype.yaml` applies. All six report zero high/critical.

Functional checks beyond "the image builds", since forcing past a cap can break a server that still builds and imports:

- `adb-mysql`: starts, 3 tools + 4 resources activate; scan exit 0
- `chroma-mcp`: 13 tools enumerated, all SAFE
- `astra-db`: 19 tools enumerated, all SAFE
- `brightdata`, `jetbrains`, `browserbase`: `initialize` + `tools/list` over stdio. These are `insecure_ignore: true` so mcp-scan cannot enumerate them
- `browserbase` additionally: `sharp` 0.35.3 loads against libvips 8.18.3 and round-trips a create/resize/re-encode

## Not fixed, and why

**`mcp-neo4j-cypher`, `mcp-neo4j-aura-manager`, `mcp-neo4j-memory`.** Every `fastmcp` advisory below 3.2.0 is patched only at 3.2.0 with no 2.x backport, so the fix must cross 2.x to 3.x, and upstream caps `fastmcp<3`. Forcing 3.x was tested: the image builds, `import mcp_neo4j_cypher` succeeds, then `create_mcp_server()` raises `TypeError: FastMCP() no longer accepts 'stateless_http'`. All three pass that constructor kwarg, which 3.x removed with a hard raise. Needs an upstream release, not an override. See #830 for the full write-up, and #528, which would make cypher's posture worse rather than better.

**`mcp-server-neon`.** The npm package is deprecated in favor of a hosted server, last published 0.6.5 which is already what we pin, and upstream's `main` is now a Next.js app never published under that name. Its ~30 exact-pinned deps produce 86 findings including a `next` critical. Tracked separately for removal rather than patched.

## Note on the neo4j finding

Those three are `insecure_ignore: true`, so mcp-scan cannot enumerate their tools and would have passed a startup-breaking override straight through. The "the scan also validates the override" property from #831 only holds for scannable servers. Worth remembering before trusting a green scan on an `insecure_ignore` server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)