### PR TITLE
fix(ci): make the periodic security scan actually report findings

### DIFF
--- a/.github/workflows/periodic-security-scan.yml
+++ b/.github/workflows/periodic-security-scan.yml
@@ -87,13 +87,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The SARIF feed exists for visibility in the Security tab, so it stays
+      # broad on purpose: every severity, including findings with no fix
+      # available. Narrowing it would silently drop existing coverage. Note
+      # severity-cutoff only feeds grype's --fail-on and does not filter the
+      # report, so with fail-build disabled it has no effect here; only-fixed is
+      # what would filter, and it is deliberately absent.
       - name: Run Grype vulnerability scan (SARIF)
         id: grype-scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: "${{ steps.meta.outputs.image_ref }}"
-          severity-cutoff: "high"
-          only-fixed: "true"
           fail-build: "false"
           output-format: "sarif"
 

--- a/.github/workflows/periodic-security-scan.yml
+++ b/.github/workflows/periodic-security-scan.yml
@@ -191,6 +191,13 @@ jobs:
             body += `\n---\n`;
             body += `_Automated security scan from [periodic-security-scan workflow](../actions/workflows/periodic-security-scan.yml)_`;
 
+            // Label by what was actually found, so a high-only issue is not
+            // labelled critical. security+grype are always applied and are what
+            // the dedup query below matches on.
+            const labels = ['security', 'grype'];
+            if (critical > 0) labels.push('critical');
+            if (high > 0) labels.push('high');
+
             // Check if an issue already exists for this image
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -219,7 +226,7 @@ jobs:
                 repo: context.repo.repo,
                 title: `🚨 Security: Critical or high vulnerabilities in ${{ steps.meta.outputs.server_name }} container`,
                 body: body,
-                labels: ['security', 'grype', 'critical']
+                labels: labels
               });
               console.log('Created new security issue');
             }

--- a/.github/workflows/periodic-security-scan.yml
+++ b/.github/workflows/periodic-security-scan.yml
@@ -92,7 +92,9 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: "${{ steps.meta.outputs.image_ref }}"
-          severity-cutoff: "low"
+          severity-cutoff: "high"
+          only-fixed: "true"
+          fail-build: "false"
           output-format: "sarif"
 
       - name: Upload SARIF to GitHub Security
@@ -107,10 +109,12 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
           image: "${{ steps.meta.outputs.image_ref }}"
-          severity-cutoff: "low"
+          severity-cutoff: "high"
+          only-fixed: "true"
+          fail-build: "false"
           output-format: "json"
 
-      - name: Check for critical issues
+      - name: Check for critical or high issues
         id: check-critical
         run: |
           critical=$(jq '[.matches[]? | select(.vulnerability.severity == "Critical")] | length' ${{ steps.grype-scan-json.outputs.json }})
@@ -119,13 +123,16 @@ jobs:
           echo "critical=$critical" >> $GITHUB_OUTPUT
           echo "high=$high" >> $GITHUB_OUTPUT
 
-          if [ "$critical" -gt 0 ]; then
+          # Match the publish gate in build-containers.yml: any fixable
+          # critical or high finding is enough to block a release, so it is
+          # also enough to warrant an issue.
+          if [ "$((critical + high))" -gt 0 ]; then
             echo "should_create_issue=true" >> $GITHUB_OUTPUT
           else
             echo "should_create_issue=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create issue for critical findings
+      - name: Create issue for critical or high findings
         if: steps.check-critical.outputs.should_create_issue == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -139,7 +146,7 @@ jobs:
             const high = ${{ steps.check-critical.outputs.high }};
 
             let body = `## 🚨 Security Scan Alert\n\n`;
-            body += `A periodic security scan found critical issues in the container image:\n\n`;
+            body += `A periodic security scan found fixable critical or high severity vulnerabilities in the container image. Findings at this level also block publishing in the build workflow.\n\n`;
             body += `- **Image**: \`${{ steps.meta.outputs.image_ref }}\`\n`;
             body += `- **Critical vulnerabilities**: ${critical}\n`;
             body += `- **High vulnerabilities**: ${high}\n\n`;
@@ -159,6 +166,21 @@ jobs:
 
               if (critical > 5) {
                 body += `\n_... and ${critical - 5} more. See Security tab for complete list._\n`;
+              }
+            }
+
+            if (high > 0) {
+              body += `#### High Vulnerabilities\n\n`;
+              const highVulns = (results.matches || [])
+                .filter(m => m.vulnerability.severity === 'High')
+                .slice(0, 5);
+
+              for (const match of highVulns) {
+                body += `- **${match.vulnerability.id}** in \`${match.artifact.name}@${match.artifact.version}\`: ${match.vulnerability.description || 'No description'}\n`;
+              }
+
+              if (high > 5) {
+                body += `\n_... and ${high - 5} more. See Security tab for complete list._\n`;
               }
             }
 
@@ -191,7 +213,7 @@ jobs:
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `🚨 Security: Critical issues in ${{ steps.meta.outputs.server_name }} container`,
+                title: `🚨 Security: Critical or high vulnerabilities in ${{ steps.meta.outputs.server_name }} container`,
                 body: body,
                 labels: ['security', 'grype', 'critical']
               });
@@ -218,7 +240,7 @@ jobs:
         run: |
           echo "## Periodic Security Scan Complete" >> $GITHUB_STEP_SUMMARY
           echo "- **Scan Type**: Vulnerability scan (Grype)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Severity Levels**: CRITICAL, HIGH, MEDIUM, LOW" >> $GITHUB_STEP_SUMMARY
+          echo "- **Severity Levels**: CRITICAL, HIGH (fixable only, matching the publish gate)" >> $GITHUB_STEP_SUMMARY
           echo "- **Status**: ${{ needs.scan-images.result }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "View detailed results in the [Security tab](../../security/code-scanning)." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #829

The weekly scan has failed every run for at least five weeks and has never filed an issue. Two independent problems, both fixed here.

**1. The job aborted before it could report.** The SARIF scan step ran at `severity-cutoff: low` with no `fail-build`, and `anchore/scan-action` defaults that to `true`, so it failed on essentially any finding. `Upload SARIF` survived on `if: always()`, but the JSON scan, the count check, and the issue creation were all skipped. Both scan steps now set `fail-build: false` so `Check for critical or high issues` decides the outcome.

**2. Its alerting threshold sat above the publish gate.** `build-containers` blocks at high, while this filed issues only on critical, so a finding serious enough to block a publish produced no notification. `high` was already computed and then unused. The gate is now `critical + high > 0`, and the JSON step matches the publish gate exactly (`severity-cutoff: high`, `only-fixed: true`).

**The SARIF feed stays deliberately broad.** Aligning it too would have narrowed the Security tab, since `only-fixed` drops findings with no available fix and the `periodic-grype-*` categories carry them today. It keeps only `fail-build: false`. Worth knowing: `severity-cutoff` only feeds grype's `--fail-on` and does not filter the report, so `only-fixed` is the setting that would have cost coverage.

Also here: issues are labelled by what was actually found rather than always `critical`, and the issue body gained a high-severity detail block, since "5 high" with no specifics is not actionable.

## Verification

This cannot be exercised without a scheduled run, so the checks are static:

- YAML parses.
- Input names and defaults read from the pinned action rather than from memory: `fail-build` does default to `"true"`, confirming the mechanism; `severity-cutoff` is only passed as `--fail-on` and does not filter output, so the jq counts stay correct.
- `actionlint` is not installed here, so it was not run.
- jq handles absent and empty `.matches`, giving `should_create_issue=false` rather than an arithmetic error.
- Step paths after the change: on findings, every step now runs through to issue creation. Only a genuine error (registry auth, missing image, grype crash) fails a scan step, and `Upload SARIF` and `Upload scan results` keep `if: always()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)