### PR TITLE
fix(skills): sync mattpocock/skills to bb8fdc3, add wait-what

### DIFF
--- a/skills/ask-matt/spec.yaml
+++ b/skills/ask-matt/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/ask-matt"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/codebase-design/spec.yaml
+++ b/skills/codebase-design/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/codebase-design"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/diagnosing-bugs/spec.yaml
+++ b/skills/diagnosing-bugs/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/diagnosing-bugs"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/domain-modeling/spec.yaml
+++ b/skills/domain-modeling/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/domain-modeling"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/git-guardrails-claude-code/spec.yaml
+++ b/skills/git-guardrails-claude-code/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/misc/git-guardrails-claude-code"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/grill-with-docs/spec.yaml
+++ b/skills/grill-with-docs/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/grill-with-docs"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/grilling/spec.yaml
+++ b/skills/grilling/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/productivity/grilling"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/handoff/spec.yaml
+++ b/skills/handoff/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/productivity/handoff"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/implement/spec.yaml
+++ b/skills/implement/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/implement"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/improve-codebase-architecture/spec.yaml
+++ b/skills/improve-codebase-architecture/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/improve-codebase-architecture"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/matt-pocock-code-review/spec.yaml
+++ b/skills/matt-pocock-code-review/spec.yaml
@@ -11,9 +11,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/code-review"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/migrate-to-shoehorn/spec.yaml
+++ b/skills/migrate-to-shoehorn/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/misc/migrate-to-shoehorn"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/prototype/spec.yaml
+++ b/skills/prototype/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/prototype"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/research/spec.yaml
+++ b/skills/research/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/research"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/resolving-merge-conflicts/spec.yaml
+++ b/skills/resolving-merge-conflicts/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/resolving-merge-conflicts"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/scaffold-exercises/spec.yaml
+++ b/skills/scaffold-exercises/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/misc/scaffold-exercises"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/setup-matt-pocock-skills/spec.yaml
+++ b/skills/setup-matt-pocock-skills/spec.yaml
@@ -10,9 +10,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/setup-matt-pocock-skills"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/setup-pre-commit/spec.yaml
+++ b/skills/setup-pre-commit/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/misc/setup-pre-commit"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/tdd/spec.yaml
+++ b/skills/tdd/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/tdd"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/teach/spec.yaml
+++ b/skills/teach/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/productivity/teach"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/to-questionnaire/spec.yaml
+++ b/skills/to-questionnaire/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/productivity/to-questionnaire"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/to-spec/spec.yaml
+++ b/skills/to-spec/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/to-spec"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/to-tickets/spec.yaml
+++ b/skills/to-tickets/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/to-tickets"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/triage/spec.yaml
+++ b/skills/triage/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/triage"
-  version: "0.3.0"
+  version: "0.4.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/wait-what/spec.yaml
+++ b/skills/wait-what/spec.yaml
@@ -1,17 +1,17 @@
-# Matt Pocock grill-me Skill
-# Get relentlessly interviewed about a plan or design until every branch is resolved.
+# Matt Pocock wait-what Skill
+# Stop when the last message did not land — re-pitch it plainly.
 # Source: https://github.com/mattpocock/skills
-# Will publish as: ghcr.io/stacklok/dockyard/skills/grill-me:0.1.0
+# Will publish as: ghcr.io/stacklok/dockyard/skills/wait-what:0.1.0
 
 metadata:
-  name: grill-me
-  description: "A relentless interview to sharpen a plan or design."
+  name: wait-what
+  description: "Stop. That last message did not land — re-pitch it."
 
 spec:
   repository: "https://github.com/mattpocock/skills"
   ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
-  path: "skills/productivity/grill-me"
-  version: "0.4.0"
+  path: "skills/productivity/wait-what"
+  version: "0.1.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/wayfinder/spec.yaml
+++ b/skills/wayfinder/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/wayfinder"
-  version: "0.2.0"
+  version: "0.3.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/wizard/spec.yaml
+++ b/skills/wizard/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/engineering/wizard"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"

--- a/skills/writing-for-agents/spec.yaml
+++ b/skills/writing-for-agents/spec.yaml
@@ -9,9 +9,9 @@ metadata:
 
 spec:
   repository: "https://github.com/mattpocock/skills"
-  ref: "a621cc4f755d1da9c35dc3bb3abbd1d2a3208670"  # main as of 2026-08-05
+  ref: "bb8fdc3fd12ce9729bb61f0885f51a420c3275ac"  # main as of 2026-08-06
   path: "skills/productivity/writing-for-agents"
-  version: "0.1.0"
+  version: "0.2.0"
 
 provenance:
   repository_uri: "https://github.com/mattpocock/skills"


### PR DESCRIPTION
## Summary

Follow-up to #826: bumps all vendored [mattpocock/skills](https://github.com/mattpocock/skills) from `a621cc4` (2026-08-05) to `bb8fdc3` (2026-08-06), covering 66 upstream commits including:

- **Added:** `wait-what` (`skills/productivity/wait-what`) @ `0.1.0` — new graduate from upstream
- **Ref bump + minor version bump** for all 28 existing mattpocock packages via `skillversionbump`
- Notable upstream changes in range: diagnosing-bugs secret redaction, wizard model-invocation, writing-for-agents Codex metadata fix, docs rewrites across the suite

No Dockyard packages removed — upstream cruft removal did not affect any paths we publish.

## Test plan

- [ ] `skill-version-check` CI passes
- [ ] `build-skills` CI builds and scans touched mattpocock packages