### PR TITLE
feat(skills): add Next.js Cache Components and Partial Prefetching skills

### DIFF
--- a/skills/next-cache-components-adoption/spec.yaml
+++ b/skills/next-cache-components-adoption/spec.yaml
@@ -1,0 +1,23 @@
+# Next.js next-cache-components-adoption Skill
+# Enable Cache Components and resolve blocking routes in a Next.js App Router app.
+# Source: https://github.com/vercel/next.js
+# Will publish as: ghcr.io/stacklok/dockyard/skills/next-cache-components-adoption:0.1.0
+
+metadata:
+  name: next-cache-components-adoption
+  description: "Turn on Cache Components in a Next.js app and resolve the blocking routes it surfaces. Use when the user wants to enable, adopt, or migrate to Cache Components, flip the `cacheComponents` flag, work through a flood of blocking-prerender / instant validation errors, run the `cache-components-instant-false` codemod, or decide between opting routes out with `export const instant = false` and fixing them in place."
+
+spec:
+  repository: "https://github.com/vercel/next.js"
+  ref: "ede8799c40a63a8c2a6cdbd9c52cf89218534e4c"  # canary as of 2026-08-06
+  path: "skills/next-cache-components-adoption"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/vercel/next.js"
+  repository_ref: "refs/heads/canary"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "vercel/next.js is licensed MIT in license.md at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/next-cache-components-optimizer/spec.yaml
+++ b/skills/next-cache-components-optimizer/spec.yaml
@@ -1,0 +1,24 @@
+# Next.js next-cache-components-optimizer Skill
+# Drive Next.js routes to instant navigation under Cache Components / PPR with
+# @next/playwright instant() e2e guards.
+# Source: https://github.com/vercel/next.js
+# Will publish as: ghcr.io/stacklok/dockyard/skills/next-cache-components-optimizer:0.1.0
+
+metadata:
+  name: next-cache-components-optimizer
+  description: "Drive a Next.js route to instant navigation by setting up an agentic loop, under Cache Components / PPR, on initial load (hard navigation) and client-side navigation (soft navigation). Encode the goal as a failing @next/playwright instant() e2e and work it to green, one verified route at a time; the shipped test then guards against regression. Use when asked to make a route's navigation instant (its static shell commits immediately), fix a route whose static shell isn't prerendered/served/prefetched, grow a route's static shell or fix its slow first paint, diagnose which Suspense boundary keeps a route out of its static shell, or write the instant() e2e guard for one. Requires Next.js 16.3+ with cacheComponents; directs an upgrade if older."
+
+spec:
+  repository: "https://github.com/vercel/next.js"
+  ref: "ede8799c40a63a8c2a6cdbd9c52cf89218534e4c"  # canary as of 2026-08-06
+  path: "skills/next-cache-components-optimizer"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/vercel/next.js"
+  repository_ref: "refs/heads/canary"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "vercel/next.js is licensed MIT in license.md at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/next-dev-loop/spec.yaml
+++ b/skills/next-dev-loop/spec.yaml
@@ -1,0 +1,23 @@
+# Next.js next-dev-loop Skill
+# Verify Next.js runtime behavior after edits using /_next/mcp and agent-browser.
+# Source: https://github.com/vercel/next.js
+# Will publish as: ghcr.io/stacklok/dockyard/skills/next-dev-loop:0.1.0
+
+metadata:
+  name: next-dev-loop
+  description: "Verify Next.js runtime behavior after editing app code. Use this skill to confirm a change actually works in a running app — not just that it compiles or type-checks. Combines /_next/mcp (Next.js's view) with agent-browser (the browser's view). Requires a running `next dev`."
+
+spec:
+  repository: "https://github.com/vercel/next.js"
+  ref: "ede8799c40a63a8c2a6cdbd9c52cf89218534e4c"  # canary as of 2026-08-06
+  path: "skills/next-dev-loop"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/vercel/next.js"
+  repository_ref: "refs/heads/canary"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "vercel/next.js is licensed MIT in license.md at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."

--- a/skills/next-partial-prefetching-adoption/spec.yaml
+++ b/skills/next-partial-prefetching-adoption/spec.yaml
@@ -1,0 +1,23 @@
+# Next.js next-partial-prefetching-adoption Skill
+# Enable Partial Prefetching and work through the insights it surfaces.
+# Source: https://github.com/vercel/next.js
+# Will publish as: ghcr.io/stacklok/dockyard/skills/next-partial-prefetching-adoption:0.1.0
+
+metadata:
+  name: next-partial-prefetching-adoption
+  description: "Turn on Partial Prefetching in a Next.js app and work through the insights it surfaces. Use when the user wants to enable or adopt Partial Prefetching, flip the `partialPrefetching` flag, opt routes in with `export const prefetch = 'partial'`, audit `<Link prefetch={true}>` calls, or resolve the link-prefetch-partial and instant-shell-url-data insights."
+
+spec:
+  repository: "https://github.com/vercel/next.js"
+  ref: "ede8799c40a63a8c2a6cdbd9c52cf89218534e4c"  # canary as of 2026-08-06
+  path: "skills/next-partial-prefetching-adoption"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/vercel/next.js"
+  repository_ref: "refs/heads/canary"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "vercel/next.js is licensed MIT in license.md at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."


### PR DESCRIPTION
## Summary
- Add four official skills from [`vercel/next.js` canary](https://github.com/vercel/next.js/tree/canary/skills), pinned to `ede8799c` (2026-08-06)
- Skills: `next-cache-components-adoption`, `next-cache-components-optimizer`, `next-dev-loop`, `next-partial-prefetching-adoption`
- Allowlist `MANIFEST_MISSING_LICENSE` (MIT via repo-root `license.md`; no SPDX in skill frontmatter)

## Test plan
- [ ] Confirm each `skills/*/spec.yaml` points at `https://github.com/vercel/next.js` with path under `skills/`
- [ ] CI skill security scan passes (or only expected allowlisted findings)
- [ ] Skill build/publish workflow picks up the four new artifacts