### PR TITLE
fix(dockhand): sparse-clone skills; restore stale clickhousectl pins

### DIFF
--- a/cmd/dockhand/main.go
+++ b/cmd/dockhand/main.go
@@ -927,7 +927,7 @@ func runValidateSkill(cmd *cobra.Command, cfgFile string) error {
 	cmd.Printf("Description: %s\n", result.SkillConfig.Description)
 	cmd.Printf("Version: %s\n", result.SkillConfig.Version)
 	cmd.Printf("Commit: %s\n", result.CommitHash)
-	cmd.Printf("Files: %d\n", len(result.Files))
+	cmd.Printf("Files: %d\n", result.FileCount)
 	cmd.Printf("Status: VALID\n")
 
 	return nil

--- a/internal/skills/builder.go
+++ b/internal/skills/builder.go
@@ -3,7 +3,6 @@ package skills
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -73,11 +72,6 @@ func BuildSkill(ctx context.Context, spec *SkillSpec) (*BuildResult, error) {
 		"commit", checkout.CommitHash,
 	)
 
-	skillDir := filepath.Join(checkout.RootDir, "skill")
-	if err := copyDir(checkout.SkillDir, skillDir); err != nil {
-		return nil, fmt.Errorf("copying skill files: %w", err)
-	}
-
 	storeDir := filepath.Join(checkout.RootDir, "oci-store")
 	store, err := ociskills.NewStore(storeDir)
 	if err != nil {
@@ -85,7 +79,7 @@ func BuildSkill(ctx context.Context, spec *SkillSpec) (*BuildResult, error) {
 	}
 
 	opts := ociskills.DefaultPackageOptions()
-	pkgResult, err := ociskills.NewPackager(store).Package(ctx, skillDir, opts)
+	pkgResult, err := ociskills.NewPackager(store).Package(ctx, checkout.SkillDir, opts)
 	if err != nil {
 		return nil, fmt.Errorf("packaging skill: %w", err)
 	}
@@ -176,44 +170,4 @@ func countFiles(root string) (int, error) {
 		return nil
 	})
 	return count, err
-}
-
-func copyDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-
-		if d.IsDir() {
-			return os.MkdirAll(target, 0o755)
-		}
-		if !d.Type().IsRegular() {
-			return nil
-		}
-
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return err
-		}
-
-		in, err := os.Open(path) //#nosec G304 -- path walked from a temp checkout we created
-		if err != nil {
-			return err
-		}
-		defer in.Close() //nolint:errcheck
-
-		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //#nosec G302,G304 -- skill files are non-executable content
-		if err != nil {
-			return err
-		}
-		defer out.Close() //nolint:errcheck
-
-		_, err = io.Copy(out, in)
-		return err
-	})
 }

--- a/internal/skills/builder.go
+++ b/internal/skills/builder.go
@@ -3,12 +3,14 @@ package skills
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 
 	ociskills "github.com/stacklok/toolhive-core/oci/skills"
-	"github.com/stacklok/toolhive/pkg/skills/gitresolver"
+	thvskills "github.com/stacklok/toolhive/pkg/skills"
 )
 
 // BuildResult contains the result of building a skill into an OCI artifact.
@@ -34,63 +36,57 @@ func (r *BuildResult) Cleanup() {
 	}
 }
 
+// ValidationResult contains the outcome of validating a skill without packaging.
+type ValidationResult struct {
+	SkillConfig *thvskills.ParseResult
+	CommitHash  string
+	FileCount   int
+}
+
 // BuildSkill clones a skill from a git repository and packages it as an OCI artifact.
 func BuildSkill(ctx context.Context, spec *SkillSpec) (*BuildResult, error) {
-	// Construct git reference URI from spec fields
-	gitURI, err := spec.GitReferenceURI()
-	if err != nil {
-		return nil, fmt.Errorf("constructing git reference: %w", err)
-	}
+	slog.Info("Resolving skill from git",
+		"repository", spec.Spec.Repository,
+		"ref", spec.Spec.Ref,
+		"path", spec.Spec.Path,
+	)
 
-	slog.Info("Resolving skill from git", "uri", gitURI)
-
-	// Parse the git reference
-	gitRef, err := gitresolver.ParseGitReference(gitURI)
-	if err != nil {
-		return nil, fmt.Errorf("parsing git reference %q: %w", gitURI, err)
-	}
-
-	// Resolve: clone repo, validate SKILL.md, collect files
-	resolver := gitresolver.NewResolver()
-	resolveResult, err := resolver.Resolve(ctx, gitRef)
+	checkout, err := checkoutSkill(ctx, spec.Spec.Repository, spec.Spec.Ref, spec.Spec.Path)
 	if err != nil {
 		return nil, fmt.Errorf("resolving skill from git: %w", err)
 	}
+	// Ownership of checkout.RootDir transfers to BuildResult.tmpDir on success.
+	cleanupCheckout := true
+	defer func() {
+		if cleanupCheckout {
+			checkout.Cleanup()
+		}
+	}()
+
+	parsed, err := parseAndValidateSkillMD(checkout.SkillDir)
+	if err != nil {
+		return nil, err
+	}
 
 	slog.Info("Skill resolved",
-		"name", resolveResult.SkillConfig.Name,
-		"commit", resolveResult.CommitHash,
-		"files", len(resolveResult.Files),
+		"name", parsed.Name,
+		"commit", checkout.CommitHash,
 	)
 
-	// Create a temp directory for skill files and OCI store.
-	// Caller is responsible for cleanup via CleanupBuild().
-	tmpDir, err := os.MkdirTemp("", "dockyard-skill-*")
-	if err != nil {
-		return nil, fmt.Errorf("creating temp directory: %w", err)
+	skillDir := filepath.Join(checkout.RootDir, "skill")
+	if err := copyDir(checkout.SkillDir, skillDir); err != nil {
+		return nil, fmt.Errorf("copying skill files: %w", err)
 	}
 
-	cleanupOnError := func() { _ = os.RemoveAll(tmpDir) } //#nosec G104 -- best-effort cleanup on error
-
-	skillDir := filepath.Join(tmpDir, "skill")
-	if err := gitresolver.WriteFiles(resolveResult.Files, skillDir, true); err != nil {
-		cleanupOnError()
-		return nil, fmt.Errorf("writing skill files: %w", err)
-	}
-
-	// Create OCI store for packaging
-	storeDir := filepath.Join(tmpDir, "oci-store")
+	storeDir := filepath.Join(checkout.RootDir, "oci-store")
 	store, err := ociskills.NewStore(storeDir)
 	if err != nil {
-		cleanupOnError()
 		return nil, fmt.Errorf("creating OCI store: %w", err)
 	}
 
-	// Package the skill into an OCI artifact
 	opts := ociskills.DefaultPackageOptions()
 	pkgResult, err := ociskills.NewPackager(store).Package(ctx, skillDir, opts)
 	if err != nil {
-		cleanupOnError()
 		return nil, fmt.Errorf("packaging skill: %w", err)
 	}
 
@@ -100,42 +96,124 @@ func BuildSkill(ctx context.Context, spec *SkillSpec) (*BuildResult, error) {
 		"platforms", len(pkgResult.Platforms),
 	)
 
+	cleanupCheckout = false
 	return &BuildResult{
 		PackageResult: pkgResult,
 		Store:         store,
-		CommitHash:    resolveResult.CommitHash,
-		SkillName:     resolveResult.SkillConfig.Name,
+		CommitHash:    checkout.CommitHash,
+		SkillName:     parsed.Name,
 		ImageRef:      spec.ImageTag(),
-		tmpDir:        tmpDir,
+		tmpDir:        checkout.RootDir,
 	}, nil
 }
 
 // ValidateSkill clones a skill from a git repository and validates its SKILL.md.
 // Returns the resolved metadata without packaging.
-func ValidateSkill(ctx context.Context, spec *SkillSpec) (*gitresolver.ResolveResult, error) {
-	gitURI, err := spec.GitReferenceURI()
-	if err != nil {
-		return nil, fmt.Errorf("constructing git reference: %w", err)
-	}
+func ValidateSkill(ctx context.Context, spec *SkillSpec) (*ValidationResult, error) {
+	slog.Info("Validating skill from git",
+		"repository", spec.Spec.Repository,
+		"ref", spec.Spec.Ref,
+		"path", spec.Spec.Path,
+	)
 
-	slog.Info("Validating skill from git", "uri", gitURI)
-
-	gitRef, err := gitresolver.ParseGitReference(gitURI)
-	if err != nil {
-		return nil, fmt.Errorf("parsing git reference %q: %w", gitURI, err)
-	}
-
-	resolver := gitresolver.NewResolver()
-	result, err := resolver.Resolve(ctx, gitRef)
+	checkout, err := checkoutSkill(ctx, spec.Spec.Repository, spec.Spec.Ref, spec.Spec.Path)
 	if err != nil {
 		return nil, fmt.Errorf("resolving skill from git: %w", err)
 	}
+	defer checkout.Cleanup()
+
+	parsed, err := parseAndValidateSkillMD(checkout.SkillDir)
+	if err != nil {
+		return nil, err
+	}
+
+	fileCount, err := countFiles(checkout.SkillDir)
+	if err != nil {
+		return nil, fmt.Errorf("counting skill files: %w", err)
+	}
 
 	slog.Info("Skill validated",
-		"name", result.SkillConfig.Name,
-		"commit", result.CommitHash,
-		"files", len(result.Files),
+		"name", parsed.Name,
+		"commit", checkout.CommitHash,
+		"files", fileCount,
 	)
 
-	return result, nil
+	return &ValidationResult{
+		SkillConfig: parsed,
+		CommitHash:  checkout.CommitHash,
+		FileCount:   fileCount,
+	}, nil
+}
+
+func parseAndValidateSkillMD(skillDir string) (*thvskills.ParseResult, error) {
+	skillMDPath := filepath.Join(skillDir, "SKILL.md")
+	content, err := os.ReadFile(skillMDPath) //#nosec G304 -- path is under a temp checkout we created
+	if err != nil {
+		return nil, fmt.Errorf("reading SKILL.md: %w", err)
+	}
+
+	parsed, err := thvskills.ParseSkillMD(content)
+	if err != nil {
+		return nil, fmt.Errorf("parsing SKILL.md: %w", err)
+	}
+
+	if err := thvskills.ValidateSkillName(parsed.Name); err != nil {
+		return nil, fmt.Errorf("invalid skill name in SKILL.md: %w", err)
+	}
+
+	return parsed, nil
+}
+
+func countFiles(root string) (int, error) {
+	count := 0
+	err := filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type().IsRegular() {
+			count++
+		}
+		return nil
+	})
+	return count, err
+}
+
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+
+		in, err := os.Open(path) //#nosec G304 -- path walked from a temp checkout we created
+		if err != nil {
+			return err
+		}
+		defer in.Close() //nolint:errcheck
+
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644) //#nosec G302,G304 -- skill files are non-executable content
+		if err != nil {
+			return err
+		}
+		defer out.Close() //nolint:errcheck
+
+		_, err = io.Copy(out, in)
+		return err
+	})
 }

--- a/internal/skills/gitclone.go
+++ b/internal/skills/gitclone.go
@@ -64,8 +64,8 @@ func checkoutSkill(ctx context.Context, repository, ref, skillPath string) (*ski
 	}
 
 	if skillPath != "" {
-		// --no-cone allows checking out a nested path without its parents' other children.
-		if err := runGit(ctx, repoDir, "sparse-checkout", "set", "--no-cone", skillPath); err != nil {
+		// Cone-mode sparse-checkout of the skill directory (and its children).
+		if err := runGit(ctx, repoDir, "sparse-checkout", "set", skillPath); err != nil {
 			cleanupOnError()
 			return nil, fmt.Errorf("configuring sparse-checkout for %q: %w", skillPath, err)
 		}

--- a/internal/skills/gitclone.go
+++ b/internal/skills/gitclone.go
@@ -1,0 +1,133 @@
+package skills
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// cloneTimeout bounds how long a sparse skill clone may take.
+const cloneTimeout = 5 * time.Minute
+
+// skillCheckout is a sparse checkout of a single skill directory from a git remote.
+type skillCheckout struct {
+	// RootDir is the temporary directory that owns the clone (removed by Cleanup).
+	RootDir string
+	// SkillDir is the absolute path to the skill files (SKILL.md lives here).
+	SkillDir string
+	// CommitHash is the resolved HEAD commit after checkout.
+	CommitHash string
+}
+
+// Cleanup removes the temporary clone directory.
+func (c *skillCheckout) Cleanup() {
+	if c != nil && c.RootDir != "" {
+		_ = os.RemoveAll(c.RootDir) //#nosec G104 -- best-effort cleanup of temp directory
+	}
+}
+
+// checkoutSkill clones repository at ref with a blobless/partial clone and
+// sparse-checkouts only skillPath (or the repo root when skillPath is empty).
+// This avoids go-git's in-memory LimitedFs, which cannot hold large monorepos
+// such as vercel/next.js.
+func checkoutSkill(ctx context.Context, repository, ref, skillPath string) (*skillCheckout, error) {
+	if repository == "" {
+		return nil, fmt.Errorf("repository is required")
+	}
+	if ref == "" {
+		return nil, fmt.Errorf("ref is required")
+	}
+	if err := validateGitPath(skillPath); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cloneTimeout)
+	defer cancel()
+
+	rootDir, err := os.MkdirTemp("", "dockyard-skill-src-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp directory: %w", err)
+	}
+	cleanupOnError := func() { _ = os.RemoveAll(rootDir) } //#nosec G104 -- best-effort cleanup on error
+
+	repoDir := filepath.Join(rootDir, "repo")
+
+	// Blobless clone + sparse checkout keeps large monorepos tractable.
+	if err := runGit(ctx, "", "clone", "--filter=tree:0", "--sparse", "--no-checkout", repository, repoDir); err != nil {
+		cleanupOnError()
+		return nil, fmt.Errorf("cloning repository: %w", err)
+	}
+
+	if skillPath != "" {
+		// --no-cone allows checking out a nested path without its parents' other children.
+		if err := runGit(ctx, repoDir, "sparse-checkout", "set", "--no-cone", skillPath); err != nil {
+			cleanupOnError()
+			return nil, fmt.Errorf("configuring sparse-checkout for %q: %w", skillPath, err)
+		}
+	}
+
+	if err := runGit(ctx, repoDir, "checkout", "--detach", ref); err != nil {
+		cleanupOnError()
+		return nil, fmt.Errorf("checking out ref %q: %w", ref, err)
+	}
+
+	commitHash, err := runGitOutput(ctx, repoDir, "rev-parse", "HEAD")
+	if err != nil {
+		cleanupOnError()
+		return nil, fmt.Errorf("resolving commit hash: %w", err)
+	}
+
+	skillDir := repoDir
+	if skillPath != "" {
+		skillDir = filepath.Join(repoDir, filepath.FromSlash(skillPath))
+	}
+
+	if st, err := os.Stat(skillDir); err != nil || !st.IsDir() {
+		cleanupOnError()
+		return nil, fmt.Errorf("skill path %q not found after checkout", skillPath)
+	}
+
+	return &skillCheckout{
+		RootDir:    rootDir,
+		SkillDir:   skillDir,
+		CommitHash: commitHash,
+	}, nil
+}
+
+func validateGitPath(skillPath string) error {
+	if skillPath == "" {
+		return nil
+	}
+	if filepath.IsAbs(skillPath) || strings.Contains(skillPath, "..") || strings.ContainsRune(skillPath, 0) {
+		return fmt.Errorf("invalid skill path %q", skillPath)
+	}
+	return nil
+}
+
+func runGit(ctx context.Context, dir string, args ...string) error {
+	_, err := runGitOutput(ctx, dir, args...)
+	return err
+}
+
+func runGitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...) //#nosec G204 -- args are constructed internally from validated spec fields
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("git %s: %s", args[0], msg)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}

--- a/internal/skills/gitclone_test.go
+++ b/internal/skills/gitclone_test.go
@@ -1,0 +1,31 @@
+package skills
+
+import "testing"
+
+func TestValidateGitPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{name: "empty root", path: ""},
+		{name: "nested skill", path: "skills/next-dev-loop"},
+		{name: "traversal", path: "skills/../secret", wantErr: true},
+		{name: "absolute", path: "/etc/passwd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateGitPath(tt.path)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for path %q", tt.path)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error for path %q: %v", tt.path, err)
+			}
+		})
+	}
+}

--- a/skills/clickhousectl-cloud-deploy/spec.yaml
+++ b/skills/clickhousectl-cloud-deploy/spec.yaml
@@ -9,9 +9,10 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "6e5458d59b82f6f027bccb258a7be3c6cefe5e08"  # main as of 2026-04-20
+  # Last commit that still contains this skill; 6e5458d merged it into infra-clickhouse.
+  ref: "65ce71fce803014afb69279535c82c72dc55d9ba"
   path: "skills/clickhousectl-cloud-deploy"
-  version: "0.2.5"
+  version: "0.2.6"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"

--- a/skills/clickhousectl-local-dev/spec.yaml
+++ b/skills/clickhousectl-local-dev/spec.yaml
@@ -9,9 +9,10 @@ metadata:
 
 spec:
   repository: "https://github.com/ClickHouse/agent-skills"
-  ref: "6e5458d59b82f6f027bccb258a7be3c6cefe5e08"  # main as of 2026-04-20
+  # Last commit that still contains this skill; 6e5458d merged it into infra-clickhouse.
+  ref: "65ce71fce803014afb69279535c82c72dc55d9ba"
   path: "skills/clickhousectl-local-dev"
-  version: "0.1.6"
+  version: "0.1.7"
 
 provenance:
   repository_uri: "https://github.com/ClickHouse/agent-skills"


### PR DESCRIPTION
## Summary
- Replace go-git's full in-memory clone with `git clone --filter=tree:0 --sparse` so skill validate/build only fetches the skill subdirectory
- Unblocks packaging skills hosted in large monorepos (e.g. `vercel/next.js`) that currently fail with `file too big: objects/pack/...`
- Retarget `clickhousectl-cloud-deploy` / `clickhousectl-local-dev` to the last upstream commit that still contains those paths (they were removed in `6e5458d` when merged into `infra-clickhouse`), and bump their `spec.version`s

## Test plan
- [x] `go test ./internal/skills/`
- [x] `golangci-lint run ./internal/skills/` (clean)
- [x] `dockhand validate-skill` for all four Next.js skills (VALID)
- [x] `dockhand validate-skill` for both clickhousectl skills (VALID)
- [x] `dockhand validate-skill --config skills/gh-stack/spec.yaml` (VALID)
- [x] `dockhand build-skill` for `next-dev-loop` (packages successfully)
- [ ] CI Lint / validate-skills / build-skill-artifacts pass

Blocks https://github.com/stacklok/dockyard/pull/843 until this lands.