### PR TITLE
Add HashiCorp Terraform and Packer skills

### DIFF
--- a/skills/hashicorp-aws-ami-builder/spec.yaml
+++ b/skills/hashicorp-aws-ami-builder/spec.yaml
@@ -1,0 +1,33 @@
+# HashiCorp hashicorp-aws-ami-builder Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-aws-ami-builder:0.1.0
+
+metadata:
+  name: hashicorp-aws-ami-builder
+  description: Build Amazon Machine Images (AMIs) with Packer using the amazon-ebs builder. Use when creating
+    custom AMIs for EC2 instances.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/packer/skills/aws-ami-builder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00010
+      reason: "FP: matched the documented package-manager install command (e.g. SKILL.md:58, SKILL.md:59) for the CLI/tooling covered by this skill — the vendor-recommended install step, not a hidden payload."
+    - rule_id: ATR_2026_00062
+      reason: "FP: matched placeholder tokens like `_SECRET_`/`__generated__`/`_secret_` used as example variable or env-var names in documentation (e.g. SKILL.md:120, SKILL.md:126), not real secrets."
+    - rule_id: ATR_2026_00065
+      reason: "FP: matched \"data transfer\" describing cloud egress cost considerations in documentation prose (e.g. SKILL.md:7)."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:45, SKILL.md:109) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00113
+      reason: "FP: matched documented credential-chain/identity-token setup instructions (AWS/Azure/GCP dynamic credentials, `~/.aws/credentials` path) (e.g. SKILL.md:121) — standard provider authentication guidance."

--- a/skills/hashicorp-azure-image-builder/spec.yaml
+++ b/skills/hashicorp-azure-image-builder/spec.yaml
@@ -1,0 +1,31 @@
+# HashiCorp hashicorp-azure-image-builder Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-azure-image-builder:0.1.0
+
+metadata:
+  name: hashicorp-azure-image-builder
+  description: Build Azure managed images and Azure Compute Gallery images with Packer. Use when creating
+    custom images for Azure VMs.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/packer/skills/azure-image-builder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00010
+      reason: "FP: matched the documented package-manager install command (e.g. SKILL.md:76, SKILL.md:77) for the CLI/tooling covered by this skill — the vendor-recommended install step, not a hidden payload."
+    - rule_id: ATR_2026_00065
+      reason: "FP: matched \"data transfer\" describing cloud egress cost considerations in documentation prose (e.g. SKILL.md:7)."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:55, SKILL.md:104) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00114
+      reason: "FP: matched placeholder credential values like `CLIENT_SECRET=\"your-client-secret\"` in documented example commands (e.g. SKILL.md:142) — literal placeholders, not real secrets."

--- a/skills/hashicorp-azure-verified-modules/spec.yaml
+++ b/skills/hashicorp-azure-verified-modules/spec.yaml
@@ -1,0 +1,29 @@
+# HashiCorp hashicorp-azure-verified-modules Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-azure-verified-modules:0.1.0
+
+metadata:
+  name: hashicorp-azure-verified-modules
+  description: Azure Verified Modules (AVM) requirements and best practices for developing certified Azure
+    Terraform modules. Use when creating or reviewing Azure modules that need AVM certification.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/azure-verified-modules"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. SKILL.md:114) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00060
+      reason: "FP: matched \"Azure-Verified\"/\"azure-verified\", the official Azure Verified Modules (AVM) program name, in documentation (e.g. SKILL.md:6, SKILL.md:7)."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:111, SKILL.md:223) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-new-terraform-provider/spec.yaml
+++ b/skills/hashicorp-new-terraform-provider/spec.yaml
@@ -1,0 +1,20 @@
+# HashiCorp hashicorp-new-terraform-provider Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-new-terraform-provider:0.1.0
+
+metadata:
+  name: hashicorp-new-terraform-provider
+  description: 'Use this when scaffolding a new Terraform provider with the Plugin Framework: workspace
+    layout, go module setup, provider server main.go, and a provider.go with schema and Configure. Also
+    use when a user wants to start building a provider for a new API or asks how to begin a terraform-provider-*
+    project.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/new-terraform-provider"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"

--- a/skills/hashicorp-provider-actions/spec.yaml
+++ b/skills/hashicorp-provider-actions/spec.yaml
@@ -1,0 +1,29 @@
+# HashiCorp hashicorp-provider-actions Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-actions:0.1.0
+
+metadata:
+  name: hashicorp-provider-actions
+  description: Implement Terraform Provider actions using the Plugin Framework. Use when developing imperative
+    operations that execute at lifecycle events (before/after create, update, destroy).
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-actions"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding doc prose (e.g. SKILL.md:424) describing Terraform/Packer usage guidance, not an injected directive to the agent."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. SKILL.md:25) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\" phrasing in documentation prose (e.g. SKILL.md:78), not an override instruction."

--- a/skills/hashicorp-provider-configuration/spec.yaml
+++ b/skills/hashicorp-provider-configuration/spec.yaml
@@ -1,0 +1,45 @@
+# HashiCorp hashicorp-provider-configuration Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-configuration:0.1.0
+
+metadata:
+  name: hashicorp-provider-configuration
+  description: 'Implement Terraform provider configuration and authentication with the Plugin Framework:
+    provider schema for credentials (Optional + Sensitive attributes), environment variable fallbacks, credential
+    provider chains (static config, then environment variables, shared credentials file, and platform identity),
+    unknown-value guards in Configure(), secret redaction, configure-time credential validation, and diagnostics
+    that name every source tried. Use when implementing or reviewing a provider''s Configure method or provider
+    schema, adding authentication options (API keys, tokens, profiles, credentials files, assume-role),
+    deciding how a provider should resolve credentials, debugging "no valid credential sources" or missing-credentials
+    errors, or unit testing credential resolution.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-configuration"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/case-studies.md:31, references/credential-chain.md:233) in Go/HCL/API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. references/credential-chain.md:22) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00020
+      reason: "FP: matched \"secret settings\" describing where credentials are configured in provider documentation (e.g. SKILL.md:267, references/credential-chain.md:276), not an attempt to expose secrets."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\" phrasing in documentation prose (e.g. references/credential-chain.md:109), not an override instruction."
+    - rule_id: ATR_2026_00085
+      reason: "FP: matched \"skip the identity check\"/\"skip it\" describing a documented configuration opt-out (e.g. SKILL.md:49, SKILL.md:224), not an instruction to silently bypass security."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched \"constructor\"/\"Constructor\" in Go code documentation describing struct initialization (e.g. SKILL.md:124, SKILL.md:165), not an obfuscation pattern."
+    - rule_id: ATR_2026_00113
+      reason: "FP: matched documented credential-chain/identity-token setup instructions (AWS/Azure/GCP dynamic credentials, `~/.aws/credentials` path) (e.g. references/credential-chain.md:112) — standard provider authentication guidance."
+    - rule_id: ATR_2026_00115
+      reason: "FP: matched shell `env` command usage in documented debugging examples (e.g. SKILL.md:86, SKILL.md:248), not credential dumping for exfiltration."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched the word \"reverse\"/\"opposite\" in comparative documentation prose (e.g. references/case-studies.md:3)."

--- a/skills/hashicorp-provider-docs/spec.yaml
+++ b/skills/hashicorp-provider-docs/spec.yaml
@@ -1,0 +1,28 @@
+# HashiCorp hashicorp-provider-docs Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-docs:0.1.0
+
+metadata:
+  name: hashicorp-provider-docs
+  description: Create, update, and review Terraform provider documentation for Terraform Registry using
+    HashiCorp-recommended patterns, tfplugindocs templates, and schema descriptions. Use when adding or
+    changing provider configuration, resources, data sources, ephemeral resources, list resources, functions,
+    actions, or guides; when validating generated docs; and when troubleshooting missing or incorrect Registry
+    documentation.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-docs"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. references/hashicorp-provider-docs.md:45) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-provider-ephemeral-resources/spec.yaml
+++ b/skills/hashicorp-provider-ephemeral-resources/spec.yaml
@@ -1,0 +1,27 @@
+# HashiCorp hashicorp-provider-ephemeral-resources Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-ephemeral-resources:0.1.0
+
+metadata:
+  name: hashicorp-provider-ephemeral-resources
+  description: 'Implement Terraform provider ephemeral resources with the Plugin Framework: the Open/Renew/Close
+    lifecycle, ephemeral schema design, registration via EphemeralResources, renewal for expiring credentials,
+    and how ephemeral values flow into write-only attributes and provider configuration. Use when adding
+    an ephemeral resource, exposing secrets/tokens/certificates that must never persist in state or plan,
+    deciding between an ephemeral resource and a data source, or wiring short-lived credentials from one
+    provider into another.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-ephemeral-resources"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:171) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-provider-framework-migration/spec.yaml
+++ b/skills/hashicorp-provider-framework-migration/spec.yaml
@@ -1,0 +1,33 @@
+# HashiCorp hashicorp-provider-framework-migration Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-framework-migration:0.1.0
+
+metadata:
+  name: hashicorp-provider-framework-migration
+  description: 'Migrate Terraform provider resources and data sources from Plugin SDKv2 to the Plugin Framework:
+    muxing both plugins in one provider (terraform-plugin-mux, tf5to6server), per-resource migration workflow,
+    SDKv2-to-Framework schema mapping (ForceNew, ValidateFunc, DiffSuppressFunc, Default, Timeouts, blocks),
+    null-vs-zero-value behavioral traps, and state-compatibility verification. Use when converting or translating
+    SDKv2 resources to the Framework, setting up a muxed provider server, deciding whether a resource should
+    be migrated at all, or debugging plan diffs and state errors that appeared after a migration.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-framework-migration"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding doc prose (e.g. SKILL.md:131) describing Terraform/Packer usage guidance, not an injected directive to the agent."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/\"all table\" describing bulk Terraform operations such as import or code generation in documentation (e.g. references/schema-mapping.md:3), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:140, SKILL.md:141) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched \"constructor\"/\"Constructor\" in Go code documentation describing struct initialization (e.g. references/schema-mapping.md:46), not an obfuscation pattern."

--- a/skills/hashicorp-provider-resources/spec.yaml
+++ b/skills/hashicorp-provider-resources/spec.yaml
@@ -1,0 +1,35 @@
+# HashiCorp hashicorp-provider-resources Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-resources:0.1.0
+
+metadata:
+  name: hashicorp-provider-resources
+  description: 'Implement Terraform Provider resources and data sources using the Plugin Framework: CRUD
+    operations, schema design, plan modifiers and validators, not-found handling, waiters for eventually
+    consistent APIs, import support, resource design principles, and required acceptance test coverage.
+    Use when adding or changing a resource or data source, deciding whether an API concept should be a resource,
+    wiring a resource to the provider''s configured client, handling drift or resource-not-found, or reviewing
+    a resource implementation before submission.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-resources"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding doc prose (e.g. SKILL.md:24, references/retries-and-waiters.md:5) describing Terraform/Packer usage guidance, not an injected directive to the agent."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. SKILL.md:34) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00021
+      reason: "FP: matched the literal attribute name `password` in a Terraform schema or example (e.g. SKILL.md:330) — naming a sensitive field in example code, not a leaked credential."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. references/design-principles.md:18), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:126, SKILL.md:128) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-provider-test-patterns/spec.yaml
+++ b/skills/hashicorp-provider-test-patterns/spec.yaml
@@ -1,0 +1,36 @@
+# HashiCorp hashicorp-provider-test-patterns Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-provider-test-patterns:0.1.0
+
+metadata:
+  name: hashicorp-provider-test-patterns
+  description: Terraform provider acceptance test patterns using terraform-plugin-testing with the Plugin
+    Framework. Covers test structure, TestCase/TestStep fields, ConfigStateChecks with custom statecheck.StateCheck
+    implementations, plan checks, CompareValue for cross-step assertions, config helpers, import testing
+    with ImportStateKind, sweepers, and scenario patterns (basic, update, disappears, validation, regression),
+    and ephemeral resource testing with the echoprovider package. Use when writing, reviewing, or debugging
+    provider acceptance tests, including questions about statecheck, plancheck, TestCheckFunc, CheckDestroy,
+    ExpectError, import state verification, ephemeral resources, or how to structure test files.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/provider-test-patterns"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:392) in Go/HCL/API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. references/ephemeral.md:75) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00021
+      reason: "FP: matched the literal attribute name `password` in a Terraform schema or example (e.g. references/ephemeral.md:68) — naming a sensitive field in example code, not a leaked credential."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"override\" describing Terraform variable/precedence override semantics in documentation prose (e.g. SKILL.md:107)."

--- a/skills/hashicorp-push-to-registry/spec.yaml
+++ b/skills/hashicorp-push-to-registry/spec.yaml
@@ -1,0 +1,29 @@
+# HashiCorp hashicorp-push-to-registry Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-push-to-registry:0.1.0
+
+metadata:
+  name: hashicorp-push-to-registry
+  description: Push Packer build metadata to HCP Packer registry for tracking and managing image lifecycle.
+    Use when integrating Packer builds with HCP Packer for version control and governance.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/packer/skills/push-to-registry"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00010
+      reason: "FP: matched the documented package-manager install command (e.g. SKILL.md:60, SKILL.md:61) for the CLI/tooling covered by this skill — the vendor-recommended install step, not a hidden payload."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:38, SKILL.md:130) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00114
+      reason: "FP: matched placeholder credential values like `CLIENT_SECRET=\"your-client-secret\"` in documented example commands (e.g. SKILL.md:73) — literal placeholders, not real secrets."

--- a/skills/hashicorp-refactor-module/spec.yaml
+++ b/skills/hashicorp-refactor-module/spec.yaml
@@ -1,0 +1,29 @@
+# HashiCorp hashicorp-refactor-module Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-refactor-module:0.1.0
+
+metadata:
+  name: hashicorp-refactor-module
+  description: Transform monolithic Terraform configurations into reusable, maintainable modules following
+    HashiCorp's module design principles and community best practices.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/refactor-module"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. SKILL.md:98, SKILL.md:109) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00060
+      reason: "FP: matched \"Azure-Verified\"/\"azure-verified\", the official Azure Verified Modules (AVM) program name, in documentation (e.g. SKILL.md:541)."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:171, SKILL.md:184) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-run-acceptance-tests/spec.yaml
+++ b/skills/hashicorp-run-acceptance-tests/spec.yaml
@@ -1,0 +1,24 @@
+# HashiCorp hashicorp-run-acceptance-tests Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-run-acceptance-tests:0.1.0
+
+metadata:
+  name: hashicorp-run-acceptance-tests
+  description: Guide for running acceptance tests for a Terraform provider. Use this when asked to run an
+    acceptance test or to run a test with the prefix `TestAcc`, when a test fails with missing environment
+    variables, or when diagnosing a failing or suspiciously passing acceptance test.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/run-acceptance-tests"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. SKILL.md:20), not exfiltration code."

--- a/skills/hashicorp-terraform-policy/spec.yaml
+++ b/skills/hashicorp-terraform-policy/spec.yaml
@@ -1,0 +1,49 @@
+# HashiCorp hashicorp-terraform-policy Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-terraform-policy:0.1.0
+
+metadata:
+  name: hashicorp-terraform-policy
+  description: 'Write, test, or convert Terraform Policy files (.policy.hcl, .policytest.hcl, Sentinel→tfpolicy).
+    Triggers: policy.hcl, policytest, convert sentinel, tfpolicy, write a policy.'
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/terraform-policy"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding doc prose (e.g. SKILL.md:12) describing Terraform/Packer usage guidance, not an injected directive to the agent."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/tfpolicy-author.md:275, references/tfpolicy-author.md:713) in Go/HCL/API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. references/tfpolicy-author.md:1449, references/tfpolicy-author.md:1459) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\" phrasing in documentation prose (e.g. references/verified-syntax.md:1593), not an override instruction."
+    - rule_id: ATR_2026_00040
+      reason: "FP: matched the literal string `\"root\"` in an example policy/config value (e.g. references/tfpolicy-author.md:415), not a privilege-escalation instruction."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/\"all table\" describing bulk Terraform operations such as import or code generation in documentation (e.g. references/tfpolicy-author.md:595, references/tfpolicy-author.md:604), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00062
+      reason: "FP: matched placeholder tokens like `_SECRET_`/`__generated__`/`_secret_` used as example variable or env-var names in documentation (e.g. references/tfpolicy-author.md:1527, references/tfpolicy-author.md:1531), not real secrets."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. SKILL.md:26, references/tfpolicy-author.md:18), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. references/tfpolicy-author.md:131, references/tfpolicy-author.md:147) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00083
+      reason: "FP: matched \"override\" describing Terraform variable/precedence override semantics in documentation prose (e.g. references/tfpolicy-test.md:140, references/tfpolicy-test.md:765)."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"override\" describing Terraform variable/precedence override semantics in documentation prose (e.g. references/tfpolicy-test.md:860, references/tfpolicy-test.md:1870)."
+    - rule_id: ATR_2026_00085
+      reason: "FP: matched \"skip the identity check\"/\"skip it\" describing a documented configuration opt-out (e.g. references/tfpolicy-author.md:641, references/tfpolicy-author.md:1431), not an instruction to silently bypass security."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched the word \"reverse\"/\"opposite\" in comparative documentation prose (e.g. references/tfpolicy-author.md:357, references/verified-syntax.md:139)."
+    - rule_id: PG_PII_SSN_HARVESTING
+      reason: "FP: matched \"ask missing\" phrasing in policy-authoring documentation (e.g. references/tfpolicy-author.md:710, references/verified-syntax.md:845), not SSN collection."

--- a/skills/hashicorp-terraform-search-import/spec.yaml
+++ b/skills/hashicorp-terraform-search-import/spec.yaml
@@ -1,0 +1,32 @@
+# HashiCorp hashicorp-terraform-search-import Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-terraform-search-import:0.1.0
+
+metadata:
+  name: hashicorp-terraform-search-import
+  description: Discover existing cloud resources using Terraform Search queries and bulk import them into
+    Terraform management. Use when bringing unmanaged infrastructure under Terraform control, auditing cloud
+    resources, or migrating to IaC.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/terraform-search-import"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:207, SKILL.md:378) in Go/HCL/API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/\"all table\" describing bulk Terraform operations such as import or code generation in documentation (e.g. references/MANUAL-IMPORT.md:88), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00062
+      reason: "FP: matched placeholder tokens like `_SECRET_`/`__generated__`/`_secret_` used as example variable or env-var names in documentation (e.g. SKILL.md:230), not real secrets."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. references/MANUAL-IMPORT.md:99, references/MANUAL-IMPORT.md:104) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-terraform-stacks/spec.yaml
+++ b/skills/hashicorp-terraform-stacks/spec.yaml
@@ -1,0 +1,49 @@
+# HashiCorp hashicorp-terraform-stacks Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-terraform-stacks:0.1.0
+
+metadata:
+  name: hashicorp-terraform-stacks
+  description: Comprehensive guide for working with HashiCorp Terraform Stacks. Use when creating, modifying,
+    or validating Terraform Stack configurations (.tfcomponent.hcl, .tfdeploy.hcl files), working with stack
+    components and deployments from local modules, public registry, or private registry sources, managing
+    multi-region or multi-environment infrastructure, or troubleshooting Terraform Stacks syntax and structure.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/terraform-stacks"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/api-monitoring.md:39, references/api-monitoring.md:47) in Go/HCL/API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. references/deployment-blocks.md:97, references/deployment-blocks.md:178) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00021
+      reason: "FP: matched the literal attribute name `password` in a Terraform schema or example (e.g. references/examples.md:260, references/examples.md:347) — naming a sensitive field in example code, not a leaked credential."
+    - rule_id: ATR_2026_00030
+      reason: "FP: matched prose describing Terraform's apply confirmation flow (e.g. references/troubleshooting.md:179) — documentation about requiring human approval, not skipping it."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/\"all table\" describing bulk Terraform operations such as import or code generation in documentation (e.g. SKILL.md:23, references/linked-stacks.md:187), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. SKILL.md:296, SKILL.md:371), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:211, SKILL.md:308) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00090
+      reason: "FP: matched \"Extract API Token from Credential...\" heading describing how a user's own monitoring pipeline reads its own token (e.g. references/api-monitoring.md:29), documentation prose."
+    - rule_id: ATR_2026_00111
+      reason: "FP: matched `curl -L` used to download the official HashiCorp/vendor CLI release binary (e.g. SKILL.md:425, references/api-monitoring.md:332) — a documented, vendor-published install step."
+    - rule_id: ATR_2026_00113
+      reason: "FP: matched documented credential-chain/identity-token setup instructions (AWS/Azure/GCP dynamic credentials, `~/.aws/credentials` path) (e.g. SKILL.md:146, references/deployment-blocks.md:59) — standard provider authentication guidance."
+    - rule_id: PG_PII_CREDENTIAL_HARVESTING
+      reason: "FP: matched documentation describing the user's own cloud credential storage in Terraform Cloud varsets or CI secrets (e.g. SKILL.md:255, references/api-monitoring.md:29) — configuration guidance, not credential harvesting."
+    - rule_id: PG_PII_CREDIT_CARD
+      reason: "FP: matched an illustrative example number formatted like a credit card in documentation (e.g. references/examples.md:1093), not a real leaked card number."

--- a/skills/hashicorp-terraform-style-guide/spec.yaml
+++ b/skills/hashicorp-terraform-style-guide/spec.yaml
@@ -1,0 +1,27 @@
+# HashiCorp hashicorp-terraform-style-guide Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-terraform-style-guide:0.1.0
+
+metadata:
+  name: hashicorp-terraform-style-guide
+  description: Generate Terraform HCL code following HashiCorp's official style conventions and best practices.
+    Use when writing, reviewing, or generating Terraform configurations.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/terraform-style-guide"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. SKILL.md:220), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:68, SKILL.md:192) — standard HCL/CI syntax, not injected secrets."

--- a/skills/hashicorp-terraform-test/spec.yaml
+++ b/skills/hashicorp-terraform-test/spec.yaml
@@ -1,0 +1,37 @@
+# HashiCorp hashicorp-terraform-test Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-terraform-test:0.1.0
+
+metadata:
+  name: hashicorp-terraform-test
+  description: Comprehensive guide for writing and running Terraform tests. Use when creating test files
+    (.tftest.hcl), writing test scenarios with run blocks, validating infrastructure behavior with assertions,
+    mocking providers and data sources, testing module outputs and resource configurations, or troubleshooting
+    Terraform test syntax and execution.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/terraform/skills/terraform-test"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00013
+      reason: "FP: matched example IP addresses or `internal/` package paths in Terraform configuration/code examples (e.g. SKILL.md:396, references/EXAMPLES.md:19) — standard placeholder addressing or Go module layout, not exfiltration to an internal network."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. references/CI_CD.md:43, references/CI_CD.md:44) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00083
+      reason: "FP: matched \"override\" describing Terraform variable/precedence override semantics in documentation prose (e.g. SKILL.md:73)."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"override\" describing Terraform variable/precedence override semantics in documentation prose (e.g. SKILL.md:44)."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched the word \"reverse\"/\"opposite\" in comparative documentation prose (e.g. SKILL.md:358, SKILL.md:402)."
+    - rule_id: PG_PII_CREDENTIAL_HARVESTING
+      reason: "FP: matched documentation describing the user's own cloud credential storage in Terraform Cloud varsets or CI secrets (e.g. references/CI_CD.md:80) — configuration guidance, not credential harvesting."

--- a/skills/hashicorp-windows-builder/spec.yaml
+++ b/skills/hashicorp-windows-builder/spec.yaml
@@ -1,0 +1,33 @@
+# HashiCorp hashicorp-windows-builder Skill
+# Source: https://github.com/hashicorp/agent-skills
+# Will publish as: ghcr.io/stacklok/dockyard/skills/hashicorp-windows-builder:0.1.0
+
+metadata:
+  name: hashicorp-windows-builder
+  description: Build Windows images with Packer using WinRM communicator and PowerShell provisioners. Use
+    when creating Windows AMIs, Azure images, or VMware templates.
+
+spec:
+  repository: "https://github.com/hashicorp/agent-skills"
+  ref: "4451ceca5456e79cc776efee96a744f7ac96e5bf"  # main as of 2026-08-10
+  path: "plugins/packer/skills/windows-builder"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/hashicorp/agent-skills"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "hashicorp/agent-skills is licensed MPL-2.0 at the repository root; upstream does not embed an SPDX license identifier in per-skill SKILL.md frontmatter."
+    - rule_id: ATR_2026_00010
+      reason: "FP: matched the documented Chocolatey bootstrap command `iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))` (SKILL.md:101) — the official Chocolatey install script run inside a Packer PowerShell provisioner to build a Windows image, not a hidden payload."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"exfil\"/\"upload\"/\"encrypt\" in documentation prose — either warning against exfiltration (design-principles guidance) or describing legitimate upload/encryption features (HCP Packer registry push, state upload, disk encryption) (e.g. SKILL.md:47), not exfiltration code."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched `netsh advfirewall` firewall-rule commands used to configure the Windows image being built by Packer (e.g. SKILL.md:51, SKILL.md:52) — a documented provisioner step, not a live firewall bypass."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched Terraform HCL string-interpolation syntax (`${...}`) or GitHub Actions `secrets.*` references in documented configuration/CI examples (e.g. SKILL.md:28, SKILL.md:70) — standard HCL/CI syntax, not injected secrets."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched \"constructor\"/\"Constructor\" in Go code documentation describing struct initialization (e.g. SKILL.md:147), not an obfuscation pattern."


### PR DESCRIPTION
## Summary
- Packages all 20 skills from [hashicorp/agent-skills](https://github.com/hashicorp/agent-skills) (16 Terraform, 4 Packer) at commit `4451ceca5456e79cc776efee96a744f7ac96e5bf` (main as of 2026-08-10) as Dockyard skill artifacts under `skills/hashicorp-*`.
- Names are prefixed `hashicorp-` (flat, not split by plugin) to avoid collisions with generic upstream names like `provider-docs`, `provider-actions`, and `windows-builder` in the shared skill catalog, and to avoid stutter on names that already contain "terraform" (`terraform-test`, `terraform-stacks`, etc).
- Each `spec.yaml` starts at `spec.version: 0.1.0`, per Dockyard's own-your-semver policy (docs/skill-versioning.md) — upstream's `v1.0.0` tag is a whole-repo release, not a per-skill version, and several skills' own SKILL.md frontmatter versions are 0.0.x/0.1.x anyway.
- `security.allowed_issues` entries allowlist the false positives surfaced by `skill-scanner` (HCL interpolation syntax, documented install commands like the Chocolatey/apt bootstrap, example IPs/credentials in Terraform/Packer docs, missing per-skill `license` field where upstream doesn't set one), each with cited file:line evidence.

## Test plan
- [x] `dockhand validate-skill` passes for all 20 spec.yaml files
- [x] `task scan-skill` passes cleanly (no unallowlisted findings) for all 20
- [x] `dockhand build-skill` built successfully for a sample skill (`hashicorp-terraform-test`)

Signed-off-by: Dan Barr <6922515+danbarr@users.noreply.github.com>