### PR TITLE
Add Figma agent skills for the Figma MCP server

### DIFF
--- a/skills/figma-code-connect/spec.yaml
+++ b/skills/figma-code-connect/spec.yaml
@@ -1,0 +1,38 @@
+# Figma figma-code-connect Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-code-connect:0.1.0
+
+metadata:
+  name: figma-code-connect
+  description: Creates and maintains Figma Code Connect template files that map Figma components to code
+    snippets. Use when the user mentions Code Connect, Figma component mapping, design-to-code translation,
+    or asks to create/update .figma.ts or .figma.js files.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-code-connect"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/api.md:645) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/an example SQL string in documented code snippets (e.g. references/api.md:567), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. SKILL.md:224, SKILL.md:232) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00090
+      reason: "FP: matched \"Extract `fileKey`\"/\"extract token\" describing how to parse a Figma URL or Plugin API return value in documentation (e.g. SKILL.md:26), not credential extraction."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. SKILL.md:423, references/advanced-patterns.md:114), not an obfuscation pattern."
+    - rule_id: ATR_2026_01610
+      reason: "FP: matched backtick-quoted inline code formatting in markdown (e.g. references/api.md:69) — standard Markdown code-span syntax, not shell subshell command substitution."

--- a/skills/figma-create-new-file/spec.yaml
+++ b/skills/figma-create-new-file/spec.yaml
@@ -1,0 +1,30 @@
+# Figma figma-create-new-file Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-create-new-file:0.1.0
+
+metadata:
+  name: figma-create-new-file
+  description: '**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `create_new_file` tool
+    call. NEVER call `create_new_file` directly without loading this skill first. Trigger whenever the user
+    wants a new blank Figma file — a new design, FigJam, or Slides file — or when you need a fresh file
+    before calling `use_figma`. Usage — /figma-create-new-file [editorType] [fileName] (e.g. /figma-create-new-file
+    figjam My Whiteboard, /figma-create-new-file slides Q3 Review)'
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-create-new-file"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00111
+      reason: "FP: matched `whoami`/`curl` used in a documented troubleshooting or asset-download example (e.g. SKILL.md:28, SKILL.md:30), not a live recon/download action."

--- a/skills/figma-design-to-code/spec.yaml
+++ b/skills/figma-design-to-code/spec.yaml
@@ -1,0 +1,31 @@
+# Figma figma-design-to-code Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-design-to-code:0.1.0
+
+metadata:
+  name: figma-design-to-code
+  description: '**MANDATORY prerequisite** — you MUST invoke this skill BEFORE calling the `get_design_context`
+    Figma MCP tool. You MUST trigger this skill whenever the user wants to implement, build, port, or code
+    up a Figma design as code. Example prompts (not exhaustive) are ''implement this Figma design'', ''build
+    this screen from Figma'', ''turn this Figma into code'', ''design to code''. This skill provides critical
+    instructions and steps to the agent on how to correctly implement Figma designs in code and must NOT
+    be skipped.'
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-design-to-code"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched \"reverse\"/\"opposite\"/\"inverse\" in comparative documentation prose (e.g. SKILL.md:3)."

--- a/skills/figma-generate-design/spec.yaml
+++ b/skills/figma-generate-design/spec.yaml
@@ -1,0 +1,44 @@
+# Figma figma-generate-design Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-generate-design:0.1.0
+
+metadata:
+  name: figma-generate-design
+  description: 'Use this skill alongside figma-use when the task involves translating an application page,
+    view, or multi-section layout into Figma. Triggers: ''write to Figma'', ''create in Figma from code'',
+    ''push page to Figma'', ''take this app/page and build it in Figma'', ''create a screen'', ''build a
+    landing page in Figma'', ''update the Figma screen to match code'', ''convert this modal/dialog/drawer/panel
+    to Figma''. This is the preferred workflow skill whenever the user wants to build or update a full page,
+    modal, dialog, drawer, sidebar, panel, or any composed multi-section view in Figma from code or a description.
+    Discovers design system components, variables, and styles from Code Connect files, existing screens,
+    and library search, then imports them and assembles views incrementally section-by-section using design
+    system tokens instead of hardcoded values.'
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-generate-design"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:188, SKILL.md:444) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00040
+      reason: "FP: matched \"truncate\"/\"TRUNCATE\" describing text-truncation or table-formatting behavior in documentation (e.g. SKILL.md:376), not a destructive data operation."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. references/discover-product-font.md:19, references/discover-product-font.md:58), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. references/discover-product-font.md:53) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00083
+      reason: "FP: matched \"# Override ...\" code comments describing configuration precedence in documented examples (e.g. SKILL.md:304), not an override instruction to the agent."
+    - rule_id: ATR_2026_02009
+      reason: "FP: matched a bare \"key:\" in a markdown table documenting Plugin API property names (e.g. SKILL.md:75), not a prompt-injection prompt for a missing secret."

--- a/skills/figma-generate-diagram/spec.yaml
+++ b/skills/figma-generate-diagram/spec.yaml
@@ -1,0 +1,51 @@
+# Figma figma-generate-diagram Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-generate-diagram:0.1.0
+
+metadata:
+  name: figma-generate-diagram
+  description: MANDATORY prerequisite — load this skill BEFORE every `generate_diagram` tool call. NEVER
+    call `generate_diagram` directly without loading this skill first. Trigger whenever the user asks to
+    create, generate, draw, render, sketch, or build a diagram — flowchart, architecture diagram, sequence
+    diagram, ERD or entity-relationship diagram, state diagram or state machine, gantt chart, or timeline.
+    Also trigger when the user mentions Mermaid syntax or wants a system architecture, decision tree, dependency
+    graph, API call flow, auth handshake, schema, or pipeline visualized in FigJam. Routes to type-specific
+    guidance, sets universal Mermaid constraints, and tells you when to use a different diagram type or
+    skip the tool entirely (mindmaps, pie charts, class diagrams, etc.).
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-generate-diagram"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding phrases (e.g. references/gantt.md:144, references/gantt.md:209) in the skill's own workflow prose, not an injected directive."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:84) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/an example SQL string in documented code snippets (e.g. references/architecture.md:169), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. references/architecture.md:123), not exfiltration code."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. references/erd.md:232, references/flowchart.md:42) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"ignore\" describing a specific documented prop/field to disregard in a code example (e.g. references/flowchart.md:130), not an instruction to ignore safety guidance."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. SKILL.md:45, references/flowchart.md:46), not an obfuscation pattern."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched \"reverse\"/\"opposite\"/\"inverse\" in comparative documentation prose (e.g. references/architecture.md:111, references/erd.md:35)."
+    - rule_id: ATR_2026_01980
+      reason: "FP: matched ER-diagram cardinality terminology (\"A side\"/\"B side\", references/erd.md:162) — coincidental substring overlap with an unrelated CVE signature for a different, unrelated MCP server package; no code execution or attacker-influenceable parameters here."
+    - rule_id: PG_PII_SSN_HARVESTING
+      reason: "FP: matched \"composin\" (from \"composing\") in ordinary documentation prose (e.g. SKILL.md:70), not SSN collection."

--- a/skills/figma-generate-library/spec.yaml
+++ b/skills/figma-generate-library/spec.yaml
@@ -1,0 +1,53 @@
+# Figma figma-generate-library Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-generate-library:0.1.0
+
+metadata:
+  name: figma-generate-library
+  description: Build or update a professional-grade design system in Figma from a codebase. Use when the
+    user wants to create variables/tokens, build component libraries, create individual components with
+    proper variant sets and variable bindings, set up theming (light/dark modes), document foundations,
+    or reconcile gaps between code and Figma. Also use when the user asks to create or generate any component
+    in Figma — even a single one — since components require proper variable foundations, variant states,
+    and design token bindings to be production-quality. This skill teaches WHAT to build and in WHAT ORDER
+    — it complements the `figma-use` skill which teaches HOW to call the Plugin API. Both skills should
+    be loaded together.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-generate-library"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding phrases (e.g. references/discovery-phase.md:472, references/discovery-phase.md:518) in the skill's own workflow prose, not an injected directive."
+    - rule_id: ATR_2026_00003
+      reason: "FP: matched \"Switch to Dev Mode\" (references/code-connect-setup.md:246) — Figma's own named UI feature for developers to inspect specs, not an AI jailbreak \"developer mode\" attempt."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/component-creation.md:53, references/discovery-phase.md:77) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\"/\"this is critical\" phrasing in documentation prose (e.g. references/naming-conventions.md:435, references/token-creation.md:486), not an override instruction."
+    - rule_id: ATR_2026_00040
+      reason: "FP: matched \"truncate\"/\"TRUNCATE\" describing text-truncation or table-formatting behavior in documentation (e.g. SKILL.md:155, references/documentation-creation.md:127), not a destructive data operation."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. SKILL.md:313, references/token-creation.md:137), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. references/code-connect-setup.md:176, references/component-creation.md:9) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00088
+      reason: "FP: matched \"return await clean...\"/\"return { clean...\" in example error-recovery code (e.g. references/error-recovery.md:44), not an output-billing or cost-evasion pattern."
+    - rule_id: ATR_2026_00090
+      reason: "FP: matched \"Extract `fileKey`\"/\"extract token\" describing how to parse a Figma URL or Plugin API return value in documentation (e.g. SKILL.md:59, references/discovery-phase.md:67), not credential extraction."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. references/documentation-creation.md:549), not an obfuscation pattern."
+    - rule_id: ATR_2026_02009
+      reason: "FP: matched a bare \"key:\" in a markdown table documenting Plugin API property names (e.g. references/component-creation.md:568), not a prompt-injection prompt for a missing secret."

--- a/skills/figma-implement-motion/spec.yaml
+++ b/skills/figma-implement-motion/spec.yaml
@@ -1,0 +1,45 @@
+# Figma figma-implement-motion Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-implement-motion:0.1.0
+
+metadata:
+  name: figma-implement-motion
+  description: Translates Figma motion and animations into production-ready application code. Use when implementing
+    animation/motion from a Figma design — user mentions "implement this motion", "add animation from Figma",
+    "animate this component", provides a Figma URL whose node is animated, or when `get_design_context`
+    returns motion data or instructs you to call `get_motion_context`.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-implement-motion"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/unsupported-and-fallbacks.md:56) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\"/\"this is critical\" phrasing in documentation prose (e.g. SKILL.md:74), not an override instruction."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. SKILL.md:36, SKILL.md:90), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. SKILL.md:67, references/examples-and-anti-examples.md:16) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00083
+      reason: "FP: matched \"# Override ...\" code comments describing configuration precedence in documented examples (e.g. references/motion-lint-rules.md:12), not an override instruction to the agent."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"ignore\" describing a specific documented prop/field to disregard in a code example (e.g. SKILL.md:60), not an instruction to ignore safety guidance."
+    - rule_id: ATR_2026_00090
+      reason: "FP: matched \"Extract `fileKey`\"/\"extract token\" describing how to parse a Figma URL or Plugin API return value in documentation (e.g. SKILL.md:23), not credential extraction."
+    - rule_id: ATR_2026_00111
+      reason: "FP: matched `whoami`/`curl` used in a documented troubleshooting or asset-download example (e.g. references/gotchas.md:79, references/svg-and-path-motion.md:11), not a live recon/download action."
+    - rule_id: ATR_2026_01610
+      reason: "FP: matched backtick-quoted inline code formatting in markdown (e.g. SKILL.md:114) — standard Markdown code-span syntax, not shell subshell command substitution."

--- a/skills/figma-swiftui/spec.yaml
+++ b/skills/figma-swiftui/spec.yaml
@@ -1,0 +1,51 @@
+# Figma figma-swiftui Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-swiftui:0.1.0
+
+metadata:
+  name: figma-swiftui
+  description: SwiftUI ↔ Figma translation. Use whenever the user mentions Swift, SwiftUI, iOS, iPhone,
+    or iPad — in EITHER direction — translating a Figma design into SwiftUI (design → code), or pushing
+    SwiftUI views / screens / tokens back into a Figma file (code → design). Triggers on phrases like 'implement
+    this Figma design in SwiftUI', 'build this screen in Swift', 'push this SwiftUI view to Figma', 'mirror
+    my Swift code in a Figma file', or whenever a Figma URL appears alongside `.swift` files / an `.xcodeproj`.
+    Routes to a direction-specific reference doc; loads alongside `figma-use` for the code → design path.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-swiftui"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding phrases (e.g. references/design-to-code.md:224, references/design-to-code.md:271) in the skill's own workflow prose, not an injected directive."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/code-to-design.md:92) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\"/\"this is critical\" phrasing in documentation prose (e.g. references/design-to-code.md:210), not an override instruction."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/an example SQL string in documented code snippets (e.g. references/design-to-code.md:243, references/design-to-code.md:256), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. references/code-to-design.md:94, references/code-to-design.md:120), not exfiltration code."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. references/code-to-design.md:29), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. SKILL.md:20, references/code-to-design.md:3) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00084
+      reason: "FP: matched \"ignore\" describing a specific documented prop/field to disregard in a code example (e.g. references/design-to-code.md:114, references/design-to-code.md:115), not an instruction to ignore safety guidance."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. references/design-to-code.md:29, references/design-to-code.md:105), not an obfuscation pattern."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched \"reverse\"/\"opposite\"/\"inverse\" in comparative documentation prose (e.g. references/design-to-code.md:255)."
+    - rule_id: ATR_2026_01610
+      reason: "FP: matched backtick-quoted inline code formatting in markdown (e.g. references/design-to-code.md:241) — standard Markdown code-span syntax, not shell subshell command substitution."

--- a/skills/figma-use-figjam/spec.yaml
+++ b/skills/figma-use-figjam/spec.yaml
@@ -1,0 +1,45 @@
+# Figma figma-use-figjam Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-use-figjam:0.1.0
+
+metadata:
+  name: figma-use-figjam
+  description: This skill helps agents use Figma's use_figma MCP tool in the FigJam context. Can be used
+    alongside figma-use which has foundational context for using the use_figma tool.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-use-figjam"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding phrases (e.g. references/position-figjam-nodes.md:60) in the skill's own workflow prose, not an injected directive."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. references/create-text.md:271, references/plan-board-content.md:280) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched comparative \"instead of ...\"/\"this is critical\" phrasing in documentation prose (e.g. references/create-code-block.md:65), not an override instruction."
+    - rule_id: ATR_2026_00040
+      reason: "FP: matched \"truncate\"/\"TRUNCATE\" describing text-truncation or table-formatting behavior in documentation (e.g. references/edit-text.md:133, references/edit-text.md:135), not a destructive data operation."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/an example SQL string in documented code snippets (e.g. references/create-code-block.md:75, references/create-table.md:154), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. SKILL.md:38), not exfiltration code."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. references/create-label.md:289, references/plan-board-content.md:77), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. references/batch-modify.md:55, references/batch-modify.md:66) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. references/create-text.md:267, references/create-text.md:292), not an obfuscation pattern."
+    - rule_id: ATR_2026_00111
+      reason: "FP: matched `whoami`/`curl` used in a documented troubleshooting or asset-download example (e.g. SKILL.md:24), not a live recon/download action."

--- a/skills/figma-use-motion/spec.yaml
+++ b/skills/figma-use-motion/spec.yaml
@@ -1,0 +1,30 @@
+# Figma figma-use-motion Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-use-motion:0.1.0
+
+metadata:
+  name: figma-use-motion
+  description: Motion / animation context for the `use_figma` MCP tool — animating Figma nodes via manual
+    keyframes, animation styles, easing, and timeline duration. Load alongside figma-use whenever a task
+    involves adding, editing, or inspecting animation on a node.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-use-motion"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. references/motion-patterns.md:109), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. SKILL.md:30, references/motion-patterns.md:59) — standard syntax, not injected secrets."

--- a/skills/figma-use-slides/spec.yaml
+++ b/skills/figma-use-slides/spec.yaml
@@ -1,0 +1,43 @@
+# Figma figma-use-slides Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-use-slides:0.1.0
+
+metadata:
+  name: figma-use-slides
+  description: This skill helps agents use Figma's use_figma MCP tool in the Slides context. Can be used
+    alongside figma-use which has foundational context for using the use_figma tool.
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-use-slides"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched imperative-sounding phrases (e.g. references/slide-design.md:119) in the skill's own workflow prose, not an injected directive."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:79) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00051
+      reason: "FP: matched \"every item\"/\"all files\"/an example SQL string in documented code snippets (e.g. SKILL.md:90), not a bulk-exfiltration action."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. references/slide-content.md:74), not exfiltration code."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. references/slide-design.md:87), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. references/slide-content.md:7, references/slide-content.md:76) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00088
+      reason: "FP: matched \"return await clean...\"/\"return { clean...\" in example error-recovery code (e.g. references/slide-gotchas.md:294), not an output-billing or cost-evasion pattern."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. references/slide-content.md:30, references/slide-content.md:43), not an obfuscation pattern."
+    - rule_id: ATR_2026_00140
+      reason: "FP: matched \"reverse\"/\"opposite\"/\"inverse\" in comparative documentation prose (e.g. SKILL.md:48, references/slide-grid.md:64)."

--- a/skills/figma-use/spec.yaml
+++ b/skills/figma-use/spec.yaml
@@ -1,0 +1,49 @@
+# Figma figma-use Skill
+# Source: https://github.com/figma/mcp-server-guide
+# Usage governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/) — no separate OSS
+# license is declared in this repo.
+# Will publish as: ghcr.io/stacklok/dockyard/skills/figma-use:0.1.0
+
+metadata:
+  name: figma-use
+  description: '**MANDATORY prerequisite** — you MUST invoke this skill BEFORE every `use_figma` tool call.
+    NEVER call `use_figma` directly without loading this skill first. Skipping it causes common, hard-to-debug
+    failures. Trigger whenever the user wants to perform a write action or a unique read action that requires
+    JavaScript execution in the Figma file context — e.g. create/edit/delete nodes, set up variables or
+    tokens, build components and variants, modify auto-layout or fills, bind variables to properties, or
+    inspect file structure programmatically.'
+
+spec:
+  repository: "https://github.com/figma/mcp-server-guide"
+  ref: "22b2c566d98880ebdb5a8e48eb2c66c596a6d990"  # main as of 2026-08-11
+  path: "skills/figma-use"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/figma/mcp-server-guide"
+  repository_ref: "refs/heads/main"
+
+security:
+  allowed_issues:
+    - rule_id: MANIFEST_MISSING_LICENSE
+      reason: "figma/mcp-server-guide declares no OSS license (no LICENSE file, none detected by GitHub); usage of the Figma MCP server and these skills is governed by the Figma Developer Terms (https://www.figma.com/legal/developer-terms/), referenced in the repo README."
+    - rule_id: ATR_2026_00002
+      reason: "FP: matched a markdown cross-reference link path (e.g. SKILL.md:15), not indirect prompt injection from external content."
+    - rule_id: ATR_2026_00012
+      reason: "FP: matched code-example tokens (e.g. SKILL.md:3, references/plugin-api-standalone.index.md:19) in JS/Plugin-API code snippets or shell examples — legitimate example code, not a hidden execution primitive."
+    - rule_id: ATR_2026_00040
+      reason: "FP: matched \"truncate\"/\"TRUNCATE\" describing text-truncation or table-formatting behavior in documentation (e.g. references/gotchas.md:651), not a destructive data operation."
+    - rule_id: ATR_2026_00050
+      reason: "FP: matched `while(true)` inside a troubleshooting table describing a bug to watch out for and avoid (e.g. SKILL.md:327) — documentation warning against a runaway loop, not an actual one."
+    - rule_id: ATR_2026_00063
+      reason: "FP: matched words like \"upload\"/\"compress\"/\"webhook\" describing legitimate Figma/FigJam features (asset upload, image compression, diagram composition) in documentation (e.g. SKILL.md:114, references/api-reference.md:265), not exfiltration code."
+    - rule_id: ATR_2026_00064
+      reason: "FP: matched inline code / timing values like \"at 0\"/\"at 3\" in documented animation-timing or API examples (e.g. SKILL.md:262, references/common-patterns.md:202), not a firewall or system command."
+    - rule_id: ATR_2026_00066
+      reason: "FP: matched JS/template string interpolation (`${...}`) or relative doc-link paths (`../../`) in documented code examples (e.g. SKILL.md:171, SKILL.md:375) — standard syntax, not injected secrets."
+    - rule_id: ATR_2026_00083
+      reason: "FP: matched \"# Override ...\" code comments describing configuration precedence in documented examples (e.g. references/working-with-design-systems/wwds.md:41), not an override instruction to the agent."
+    - rule_id: ATR_2026_00091
+      reason: "FP: matched escaped newline sequences (`\\n`) or similar tokens in documented code examples (e.g. SKILL.md:376, references/gotchas.md:240), not an obfuscation pattern."
+    - rule_id: ATR_2026_00130
+      reason: "FP: matched \"Explicit instruction to the agent:\" (references/gotchas.md:197) — this is the skill's own first-party workflow guidance (batch `use_figma` tool calls in parallel), not authority-claiming text embedded in external third-party content."


### PR DESCRIPTION
## Summary
- Packages all 12 skills from [figma/mcp-server-guide](https://github.com/figma/mcp-server-guide) (`figma-use` and its mode-specific companions `figma-use-figjam`/`figma-use-motion`/`figma-use-slides`, `figma-generate-design`/`figma-generate-library`/`figma-generate-diagram`, `figma-code-connect`, `figma-create-new-file`, `figma-design-to-code`, `figma-implement-motion`, `figma-swiftui`) at commit `22b2c566d98880ebdb5a8e48eb2c66c596a6d990`.
- Names already carry a `figma-` prefix upstream, so no additional namespacing was needed (no collisions with the existing catalog).
- `spec.version` starts at `0.1.0` for all 12, per Dockyard's own-your-semver policy.
- **Licensing note:** the upstream repo declares no OSS license (no LICENSE file, none detected by GitHub). The README states usage of the Figma MCP server and these skills is governed by the [Figma Developer Terms](https://www.figma.com/legal/developer-terms/), which is reflected in each `spec.yaml`'s header comment and its `MANIFEST_MISSING_LICENSE` allowlist reason rather than treated like a missing-SPDX-field gap.
- `security.allowed_issues` entries triage the false positives surfaced by `skill-scanner`. This batch skewed differently from prior ones (HashiCorp, Datadog) because these skills are written in a heavy MANDATORY/MUST/NEVER imperative style with first-party "instruction to the agent" language and lots of JS/Swift code — several findings were the scanner reading the skill's own workflow instructions as authority-claiming/injected text, backtick-quoted inline code misread as shell subshell substitution, and one coincidental substring match against an unrelated CVE signature for a different MCP server package. Each was manually verified against the actual upstream source before allowlisting.

## Test plan
- [x] `dockhand validate-skill` passes for all 12 spec.yaml files
- [x] `task scan-skill` passes cleanly (no unallowlisted findings) for all 12
- [x] `dockhand build-skill` built successfully for a sample skill (`figma-use`)