### PR TITLE
Add Upstash context7 agent skills

### DIFF
--- a/skills/context7-cli/spec.yaml
+++ b/skills/context7-cli/spec.yaml
@@ -1,0 +1,28 @@
+# Upstash context7-cli Skill
+# Source: https://github.com/upstash/context7
+# Will publish as: ghcr.io/stacklok/dockyard/skills/context7-cli:0.1.0
+
+metadata:
+  name: context7-cli
+  description: Use the ctx7 CLI to fetch library documentation, manage AI coding skills, and configure Context7
+    MCP. Activate when the user mentions "ctx7" or "context7", needs current docs for any library, wants
+    to install/search/generate skills, or needs to set up Context7 for their AI coding agent.
+
+spec:
+  repository: "https://github.com/upstash/context7"
+  ref: "ef14a58dfedb14f2d02bf7ecd0b1654b41553520"  # master as of 2026-08-11
+  path: "skills/context7-cli"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/upstash/context7"
+  repository_ref: "refs/heads/master"
+
+security:
+  allowed_issues:
+    - rule_id: ATR_2026_00088
+      reason: "FP: matched \"output is clean\" in a comment describing the CLI's plain stdout when piped (no spinners/colors) (references/docs.md:99), not a cost-evasion or output-billing pattern."
+    - rule_id: ATR_2026_00001
+      reason: "FP: matched \"Skip prompt\" describing the --mcp/--cli flags that skip the interactive setup-mode prompt (references/setup.md:11-12), not skipping human confirmation for a destructive action."
+    - rule_id: ATR_2026_00032
+      reason: "FP: matched \"instead of the current project\" describing the --global flag installing to the home directory instead of the current project directory (references/skills.md:118), ordinary CLI option documentation."

--- a/skills/context7-mcp/spec.yaml
+++ b/skills/context7-mcp/spec.yaml
@@ -1,0 +1,19 @@
+# Upstash context7-mcp Skill
+# Source: https://github.com/upstash/context7
+# Will publish as: ghcr.io/stacklok/dockyard/skills/context7-mcp:0.1.0
+
+metadata:
+  name: context7-mcp
+  description: This skill should be used when the user asks about libraries, frameworks, API references,
+    or needs code examples. Activates for setup questions, code generation involving libraries, or mentions
+    of specific frameworks like React, Vue, Next.js, Prisma, Supabase, etc.
+
+spec:
+  repository: "https://github.com/upstash/context7"
+  ref: "ef14a58dfedb14f2d02bf7ecd0b1654b41553520"  # master as of 2026-08-11
+  path: "skills/context7-mcp"
+  version: "0.1.0"
+
+provenance:
+  repository_uri: "https://github.com/upstash/context7"
+  repository_ref: "refs/heads/master"


### PR DESCRIPTION
## Summary
- Packages `context7-mcp` and `context7-cli` from [upstash/context7](https://github.com/upstash/context7) at commit `ef14a58dfedb14f2d02bf7ecd0b1654b41553520`.
- The repo ships a third skill, `find-docs`, which is intentionally skipped: it's what `ctx7 setup --cli` generates for MCP-less installs, and its content is a near-verbatim copy of `context7-cli`'s `references/docs.md` (same commands, same workflow, same wording). Packaging both would duplicate the same content under two catalog names; `context7-cli` already covers the CLI docs-fetching workflow, plus skills management and MCP setup that `find-docs` doesn't.
- MIT-licensed at the repo root — no license-related allowlist entry needed.
- `context7-mcp` scanned clean with no findings above the blocking threshold. `context7-cli` had 4 blocking findings, all verified false positives against the actual source (CLI flag docs like `--global`/`--cli`/`--mcp`, and a comment about clean piped stdout) — allowlisted with cited evidence.

## Test plan
- [x] `dockhand validate-skill` passes for both spec.yaml files
- [x] `task scan-skill` passes cleanly (no unallowlisted findings) for both
- [x] `dockhand build-skill` built successfully for both